### PR TITLE
feat: cross-machine peers, client SDK, deployment manifests, and security guides

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+.git
+.gitignore
+.dockerignore
+.DS_Store
+.idea
+.cache
+.env*
+*.md
+!shared/
+docs/
+examples/
+coverage/
+*.lcov
+*.tgz
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,15 @@ Peer discovery and messaging MCP channel for Claude Code instances.
 
 ## Architecture
 
-- `broker.ts` — Singleton HTTP daemon on localhost:7899 + SQLite. Auto-launched by the MCP server.
+- `broker.ts` — HTTP daemon (default localhost:7899) + SQLite. Auto-launched by the MCP server, or deployed separately for cross-machine use.
 - `server.ts` — MCP stdio server, one per Claude Code instance. Connects to broker, exposes tools, pushes channel notifications.
+- `client.ts` — Framework-agnostic SDK for non-Claude agents (PeersClient class).
 - `shared/types.ts` — Shared TypeScript types for broker API.
 - `shared/summarize.ts` — Auto-summary generation via gpt-5.4-nano.
 - `cli.ts` — CLI utility for inspecting broker state.
+- `Dockerfile` — Container image for the broker.
+- `docs/guides/pipelock.md` — Setup guide for scanning peer messages with pipelock.
+- `examples/` — Docker Compose and Kubernetes deployment examples.
 
 ## Running
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM oven/bun:1-alpine
+
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+COPY broker.ts ./
+COPY shared/ ./shared/
+
+# SQLite data directory (mount a volume here for persistence)
+RUN mkdir -p /data && chown bun:bun /data
+ENV CLAUDE_PEERS_DB=/data/claude-peers.db
+
+USER bun
+EXPOSE 7899
+CMD ["bun", "broker.ts"]

--- a/README.md
+++ b/README.md
@@ -40,13 +40,19 @@ claude mcp add --scope user --transport stdio claude-peers -- \
 
 Replace `~/claude-peers-mcp` with wherever you cloned it.
 
-### 3. Run Claude Code with the channel
+### 3. Run Claude Code
 
 ```bash
-claude --dangerously-skip-permissions --dangerously-load-development-channels server:claude-peers
+claude
 ```
 
-That's it. The broker daemon starts automatically the first time.
+Peer messages arrive when you call `check_messages`. The broker daemon starts automatically the first time.
+
+For **instant push notifications** (messages appear without calling `check_messages`), launch with the experimental channels flag:
+
+```bash
+claude --dangerously-load-development-channels server:claude-peers
+```
 
 > **Tip:** Add it to an alias so you don't have to type it every time:
 >
@@ -177,6 +183,20 @@ peers.startPolling((msg) => {
 // Clean up on exit
 await peers.shutdown();
 ```
+
+## Chat Platform Bridges
+
+Route peer messages to Telegram, Slack, Discord, or any chat platform. Build a
+bridge that polls the broker and forwards messages using the `PeersClient` SDK.
+
+Messages use a `[channel]` prefix for routing:
+```
+[dev] Hey, the build is broken — can you check?
+[general] Status update: deployment complete
+```
+
+See [Chat Platform Bridge Guide](docs/guides/chat-platform-bridge.md) for the
+full pattern with Telegram, Slack, and Discord examples.
 
 ## Auto-summary
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-peers
 
-Let your Claude Code instances find each other and talk. When you're running 5 sessions across different projects, any Claude can discover the others and send messages that arrive instantly.
+Let your Claude Code instances find each other and talk. When you're running 5 sessions across different projects, any Claude can discover the others and send messages that arrive instantly — on the same machine or across the network.
 
 ```
   Terminal 1 (poker-engine)          Terminal 2 (eel)
@@ -31,6 +31,13 @@ This makes claude-peers available in every Claude Code session, from any directo
 claude mcp add --scope user --transport stdio claude-peers -- bun ~/claude-peers-mcp/server.ts
 ```
 
+With secret scanning via [pipelock](https://github.com/luckyPipewrench/pipelock) ([setup guide](docs/guides/pipelock.md)):
+
+```bash
+claude mcp add --scope user --transport stdio claude-peers -- \
+  pipelock mcp proxy -- bun ~/claude-peers-mcp/server.ts
+```
+
 Replace `~/claude-peers-mcp` with wherever you cloned it.
 
 ### 3. Run Claude Code with the channel
@@ -47,6 +54,8 @@ That's it. The broker daemon starts automatically the first time.
 > alias claudepeers='claude --dangerously-load-development-channels server:claude-peers'
 > ```
 
+> **Note:** The `--dangerously-load-development-channels` flag enables instant message push via channel notifications. Without it, messages are buffered and available via the `check_messages` tool.
+
 ### 4. Open a second session and try it
 
 In another terminal, start Claude Code the same way. Then ask either one:
@@ -61,12 +70,12 @@ The other Claude receives it immediately and responds.
 
 ## What Claude can do
 
-| Tool             | What it does                                                                   |
-| ---------------- | ------------------------------------------------------------------------------ |
-| `list_peers`     | Find other Claude Code instances — scoped to `machine`, `directory`, or `repo` |
-| `send_message`   | Send a message to another instance by ID (arrives instantly via channel push)  |
-| `set_summary`    | Describe what you're working on (visible to other peers)                       |
-| `check_messages` | Manually check for messages (fallback if not using channel mode)               |
+| Tool             | What it does                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------- |
+| `list_peers`     | Find other Claude Code instances — scoped to `machine`, `directory`, `repo`, or `network`   |
+| `send_message`   | Send a message to another instance by ID (arrives instantly via channel push)                |
+| `set_summary`    | Describe what you're working on (visible to other peers)                                    |
+| `check_messages` | Manually check for messages (fallback if not using channel mode)                            |
 
 ## How it works
 
@@ -84,7 +93,78 @@ A **broker daemon** runs on `localhost:7899` with a SQLite database. Each Claude
                       Claude A         Claude B
 ```
 
-The broker auto-launches when the first session starts. It cleans up dead peers automatically. Everything is localhost-only.
+The broker auto-launches when the first session starts. It cleans up dead peers automatically using heartbeat-based liveness detection. By default, everything is localhost-only.
+
+## Cross-machine networking
+
+Connect Claude Code instances across multiple machines by deploying the broker on a shared host.
+
+### 1. Start the broker on a shared machine
+
+```bash
+CLAUDE_PEERS_HOST=0.0.0.0 CLAUDE_PEERS_TOKEN=your-secret-token bun broker.ts
+```
+
+Or deploy with Docker:
+
+```bash
+cd examples/docker
+CLAUDE_PEERS_TOKEN=your-secret-token docker compose up -d
+```
+
+Or Kubernetes:
+
+```bash
+kubectl create namespace claude-peers
+kubectl create secret generic claude-peers-auth -n claude-peers --from-literal=token=YOUR_TOKEN
+kubectl apply -f examples/kubernetes/broker.yaml
+```
+
+### 2. Point clients at the broker
+
+On each machine, set the broker URL and token when registering the MCP server:
+
+```bash
+claude mcp add --scope user --transport stdio claude-peers -- \
+  env CLAUDE_PEERS_URL=http://broker-host:7899 CLAUDE_PEERS_TOKEN=your-secret-token \
+  bun ~/claude-peers-mcp/server.ts
+```
+
+### 3. Discover peers across machines
+
+> List all peers on the network
+
+The `network` scope shows all peers across all machines. The `machine` scope filters to same-hostname only.
+
+## Client SDK
+
+For non-Claude agents (LangChain, CrewAI, custom scripts), use the client SDK directly:
+
+```typescript
+import { PeersClient } from './client.ts';
+
+const peers = new PeersClient({
+  brokerUrl: 'http://broker:7899',
+  token: 'your-auth-token',
+  hostname: 'my-machine',
+  summary: 'Research agent working on market analysis',
+});
+
+await peers.register({ cwd: '/workspace', gitRoot: null });
+const others = await peers.listPeers('network');
+await peers.sendMessage(others[0].id, 'Hey, what are you working on?');
+
+// Auto-heartbeat keeps your registration alive
+peers.startHeartbeat();
+
+// Auto-poll checks for messages on an interval
+peers.startPolling((msg) => {
+  console.log(`Message from ${msg.from_id}: ${msg.text}`);
+});
+
+// Clean up on exit
+await peers.shutdown();
+```
 
 ## Auto-summary
 
@@ -99,19 +179,49 @@ You can also inspect and interact from the command line:
 ```bash
 cd ~/claude-peers-mcp
 
-bun cli.ts status            # broker status + all peers
-bun cli.ts peers             # list peers
-bun cli.ts send <id> <msg>   # send a message into a Claude session
-bun cli.ts kill-broker       # stop the broker
+bun cli.ts status              # broker status + all peers
+bun cli.ts peers               # list peers on this machine
+bun cli.ts peers --network     # list peers across all machines
+bun cli.ts send <id> <msg>     # send a message into a Claude session
+bun cli.ts kill-broker         # stop the broker
 ```
+
+Set `CLAUDE_PEERS_URL` and `CLAUDE_PEERS_TOKEN` to use with a remote broker.
 
 ## Configuration
 
-| Environment variable | Default              | Description                           |
-| -------------------- | -------------------- | ------------------------------------- |
-| `CLAUDE_PEERS_PORT`  | `7899`               | Broker port                           |
-| `CLAUDE_PEERS_DB`    | `~/.claude-peers.db` | SQLite database path                  |
-| `OPENAI_API_KEY`     | —                    | Enables auto-summary via gpt-5.4-nano |
+| Environment variable     | Default              | Description                                          |
+| ------------------------ | -------------------- | ---------------------------------------------------- |
+| `CLAUDE_PEERS_PORT`      | `7899`               | Broker listen port                                   |
+| `CLAUDE_PEERS_HOST`      | `127.0.0.1`          | Broker bind address (`0.0.0.0` for network access)   |
+| `CLAUDE_PEERS_DB`        | `~/.claude-peers.db` | SQLite database path                                 |
+| `CLAUDE_PEERS_URL`       | —                    | Broker URL for remote connections (client/server)    |
+| `CLAUDE_PEERS_TOKEN`     | —                    | Bearer token for broker authentication               |
+| `CLAUDE_PEERS_HOSTNAME`  | `os.hostname()`      | Override hostname sent during registration           |
+| `OPENAI_API_KEY`         | —                    | Enables auto-summary via gpt-5.4-nano                |
+
+## Security
+
+When exposing the broker beyond localhost:
+
+- **`CLAUDE_PEERS_TOKEN` is required** — the broker refuses to bind to non-loopback addresses without a token. All POST endpoints require it via `Authorization: Bearer <token>`
+- **Use a private network** — deploy behind a VPN, tailnet, or in a cluster-internal network
+- **Scan peer messages** — wrap the MCP server with [pipelock](https://github.com/luckyPipewrench/pipelock) for DLP and injection scanning ([setup guide](docs/guides/pipelock.md))
+
+**Trust model:** The bearer token controls access to the broker — who can connect. It does not authenticate individual peer identity. Hostname and peer ID are self-reported by clients. If you need verified sender identity, add an authentication layer in front of the broker.
+
+The `/health` endpoint (GET) is unauthenticated for monitoring.
+
+## Docker
+
+Build and run the broker as a container:
+
+```bash
+docker build -t claude-peers-broker .
+docker run -d -p 7899:7899 -e CLAUDE_PEERS_HOST=0.0.0.0 -e CLAUDE_PEERS_TOKEN=changeme claude-peers-broker
+```
+
+See [examples/docker/docker-compose.yaml](examples/docker/docker-compose.yaml) for a compose setup and [examples/kubernetes/broker.yaml](examples/kubernetes/broker.yaml) for Kubernetes.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ kubectl create secret generic claude-peers-auth -n claude-peers --from-literal=t
 kubectl apply -f examples/kubernetes/broker.yaml
 ```
 
+To add secret scanning on all broker traffic, use the pipelock-enhanced deployments instead:
+
+```bash
+# Docker with pipelock
+docker compose -f examples/docker/docker-compose-with-pipelock.yaml up -d
+
+# Kubernetes with pipelock
+kubectl apply -f examples/kubernetes/broker-with-pipelock.yaml
+```
+
+See [Pipelock Integration Guide](docs/guides/pipelock.md) for the full setup.
+
 ### 2. Point clients at the broker
 
 On each machine, set the broker URL and token when registering the MCP server:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Let your Claude Code instances find each other and talk. When you're running 5 s
   └───────────────────────┘          └──────────────────────┘
 ```
 
+## Prerequisites
+
+- [Bun](https://bun.sh) (JavaScript runtime — required)
+- Claude Code v2.1.80+
+- claude.ai login (channels require it — API key auth won't work)
+
+Install Bun if you don't have it:
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
 ## Quick start
 
 ### 1. Install
@@ -31,14 +43,77 @@ This makes claude-peers available in every Claude Code session, from any directo
 claude mcp add --scope user --transport stdio claude-peers -- bun ~/claude-peers-mcp/server.ts
 ```
 
-With secret scanning via [pipelock](https://github.com/luckyPipewrench/pipelock) ([setup guide](docs/guides/pipelock.md)):
+Or add it directly in your `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-peers": {
+      "type": "stdio",
+      "command": "bun",
+      "args": ["/path/to/claude-peers-mcp/server.ts"]
+    }
+  }
+}
+```
+
+#### With environment variables (cross-machine)
+
+When connecting to a remote broker, pass `CLAUDE_PEERS_URL` and `CLAUDE_PEERS_TOKEN` via the `env` block:
+
+```json
+{
+  "mcpServers": {
+    "claude-peers": {
+      "type": "stdio",
+      "command": "bun",
+      "args": ["/path/to/claude-peers-mcp/server.ts"],
+      "env": {
+        "CLAUDE_PEERS_URL": "http://broker-host:7899",
+        "CLAUDE_PEERS_TOKEN": "your-secret-token"
+      }
+    }
+  }
+}
+```
+
+#### With pipelock scanning
+
+When wrapping through [pipelock](https://github.com/luckyPipewrench/pipelock) ([setup guide](docs/guides/pipelock.md)), use `--env` flags **before** `--` to pass environment variables through the proxy to the MCP server:
 
 ```bash
 claude mcp add --scope user --transport stdio claude-peers -- \
-  pipelock mcp proxy -- bun ~/claude-peers-mcp/server.ts
+  pipelock mcp proxy --env CLAUDE_PEERS_URL --env CLAUDE_PEERS_TOKEN -- \
+  bun ~/claude-peers-mcp/server.ts
 ```
 
-Replace `~/claude-peers-mcp` with wherever you cloned it.
+Or in `.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-peers": {
+      "type": "stdio",
+      "command": "pipelock",
+      "args": [
+        "mcp", "proxy",
+        "--env", "CLAUDE_PEERS_URL",
+        "--env", "CLAUDE_PEERS_TOKEN",
+        "--",
+        "bun", "/path/to/claude-peers-mcp/server.ts"
+      ],
+      "env": {
+        "CLAUDE_PEERS_URL": "http://broker-host:7899",
+        "CLAUDE_PEERS_TOKEN": "your-secret-token"
+      }
+    }
+  }
+}
+```
+
+The `--env` flags tell pipelock to forward those environment variables to the child process. Without them, the MCP server won't see the broker URL or token.
+
+Replace `/path/to/claude-peers-mcp` with wherever you cloned it.
 
 ### 3. Run Claude Code
 
@@ -140,7 +215,9 @@ See [Pipelock Integration Guide](docs/guides/pipelock.md) for the full setup.
 
 ### 2. Point clients at the broker
 
-On each machine, set the broker URL and token when registering the MCP server:
+On each machine, set the broker URL and token. The recommended approach is to add the `env` block in `.claude.json` (see [Register the MCP server](#2-register-the-mcp-server) above for full examples).
+
+Or via the CLI:
 
 ```bash
 claude mcp add --scope user --transport stdio claude-peers -- \
@@ -257,6 +334,4 @@ See [examples/docker/docker-compose.yaml](examples/docker/docker-compose.yaml) f
 
 ## Requirements
 
-- [Bun](https://bun.sh)
-- Claude Code v2.1.80+
-- claude.ai login (channels require it — API key auth won't work)
+See [Prerequisites](#prerequisites) at the top of this file.

--- a/broker.ts
+++ b/broker.ts
@@ -181,14 +181,8 @@ function handleRegister(body: RegisterRequest): RegisterResponse {
   const now = new Date().toISOString();
   const hostname = body.hostname || "localhost";
 
-  // Remove any existing registration for this PID + hostname combo (re-registration)
-  const existing = db
-    .query("SELECT id FROM peers WHERE pid = ? AND hostname = ?")
-    .get(body.pid, hostname) as { id: string } | null;
-  if (existing) {
-    deletePeer.run(existing.id);
-  }
-
+  // No dedup by pid/hostname — self-reported fields can collide across clients.
+  // Old registrations expire via heartbeat timeout (45s).
   insertPeer.run(id, body.pid, hostname, body.cwd, body.git_root, body.tty, body.summary, now, now);
   return { id };
 }

--- a/broker.ts
+++ b/broker.ts
@@ -2,11 +2,17 @@
 /**
  * claude-peers broker daemon
  *
- * A singleton HTTP server on localhost:7899 backed by SQLite.
+ * A singleton HTTP server backed by SQLite.
  * Tracks all registered Claude Code peers and routes messages between them.
  *
  * Auto-launched by the MCP server if not already running.
  * Run directly: bun broker.ts
+ *
+ * Environment variables:
+ *   CLAUDE_PEERS_PORT  — Listen port (default: 7899)
+ *   CLAUDE_PEERS_HOST  — Bind address (default: 127.0.0.1, use 0.0.0.0 for network)
+ *   CLAUDE_PEERS_DB    — SQLite database path (default: ~/.claude-peers.db)
+ *   CLAUDE_PEERS_TOKEN — Optional bearer token for auth (required when host != 127.0.0.1)
  */
 
 import { Database } from "bun:sqlite";
@@ -24,7 +30,21 @@ import type {
 } from "./shared/types.ts";
 
 const PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
+const HOST = process.env.CLAUDE_PEERS_HOST ?? "127.0.0.1";
 const DB_PATH = process.env.CLAUDE_PEERS_DB ?? `${process.env.HOME}/.claude-peers.db`;
+const AUTH_TOKEN = process.env.CLAUDE_PEERS_TOKEN ?? "";
+
+// Require auth when binding to network
+if (HOST !== "127.0.0.1" && HOST !== "localhost" && !AUTH_TOKEN) {
+  console.error(
+    "[claude-peers broker] FATAL: CLAUDE_PEERS_TOKEN is required when binding to " +
+      `${HOST}. Set CLAUDE_PEERS_TOKEN to a shared secret.`
+  );
+  process.exit(1);
+}
+
+// Heartbeat timeout: peers not seen for this long are considered dead (45s = 3 missed heartbeats)
+const HEARTBEAT_TIMEOUT_MS = 45_000;
 
 // --- Database setup ---
 
@@ -36,6 +56,7 @@ db.run(`
   CREATE TABLE IF NOT EXISTS peers (
     id TEXT PRIMARY KEY,
     pid INTEGER NOT NULL,
+    hostname TEXT NOT NULL DEFAULT 'localhost',
     cwd TEXT NOT NULL,
     git_root TEXT,
     tty TEXT,
@@ -44,6 +65,13 @@ db.run(`
     last_seen TEXT NOT NULL
   )
 `);
+
+// Migration: add hostname column if missing (upgrading from pre-cross-machine schema)
+try {
+  db.run("ALTER TABLE peers ADD COLUMN hostname TEXT NOT NULL DEFAULT 'localhost'");
+} catch {
+  // Column already exists — expected on subsequent runs
+}
 
 db.run(`
   CREATE TABLE IF NOT EXISTS messages (
@@ -58,18 +86,16 @@ db.run(`
   )
 `);
 
-// Clean up stale peers (PIDs that no longer exist) on startup
+// Clean up stale peers based on heartbeat timeout (works cross-machine, unlike PID checks)
 function cleanStalePeers() {
-  const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
-  for (const peer of peers) {
-    try {
-      // Check if process is still alive (signal 0 doesn't kill, just checks)
-      process.kill(peer.pid, 0);
-    } catch {
-      // Process doesn't exist, remove it
-      db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
-      db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
-    }
+  const cutoff = new Date(Date.now() - HEARTBEAT_TIMEOUT_MS).toISOString();
+  const stale = db.query("SELECT id FROM peers WHERE last_seen < ?").all(cutoff) as { id: string }[];
+  for (const peer of stale) {
+    db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
+    db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
+  }
+  if (stale.length > 0) {
+    console.error(`[claude-peers broker] Cleaned ${stale.length} stale peer(s)`);
   }
 }
 
@@ -81,8 +107,8 @@ setInterval(cleanStalePeers, 30_000);
 // --- Prepared statements ---
 
 const insertPeer = db.prepare(`
-  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, registered_at, last_seen)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO peers (id, pid, hostname, cwd, git_root, tty, summary, registered_at, last_seen)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateLastSeen = db.prepare(`
@@ -99,6 +125,10 @@ const deletePeer = db.prepare(`
 
 const selectAllPeers = db.prepare(`
   SELECT * FROM peers
+`);
+
+const selectPeersByHostname = db.prepare(`
+  SELECT * FROM peers WHERE hostname = ?
 `);
 
 const selectPeersByDirectory = db.prepare(`
@@ -133,24 +163,43 @@ function generateId(): string {
   return id;
 }
 
+// --- Auth middleware ---
+
+function checkAuth(req: Request): Response | null {
+  if (!AUTH_TOKEN) return null; // No auth configured
+  const header = req.headers.get("Authorization");
+  if (header !== `Bearer ${AUTH_TOKEN}`) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
 // --- Request handlers ---
 
 function handleRegister(body: RegisterRequest): RegisterResponse {
   const id = generateId();
   const now = new Date().toISOString();
+  const hostname = body.hostname || "localhost";
 
-  // Remove any existing registration for this PID (re-registration)
-  const existing = db.query("SELECT id FROM peers WHERE pid = ?").get(body.pid) as { id: string } | null;
+  // Remove any existing registration for this PID + hostname combo (re-registration)
+  const existing = db
+    .query("SELECT id FROM peers WHERE pid = ? AND hostname = ?")
+    .get(body.pid, hostname) as { id: string } | null;
   if (existing) {
     deletePeer.run(existing.id);
   }
 
-  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now);
+  insertPeer.run(id, body.pid, hostname, body.cwd, body.git_root, body.tty, body.summary, now, now);
   return { id };
 }
 
-function handleHeartbeat(body: HeartbeatRequest): void {
+function handleHeartbeat(body: HeartbeatRequest): { found: boolean } {
+  const peer = db.query("SELECT id FROM peers WHERE id = ?").get(body.id);
+  if (!peer) {
+    return { found: false };
+  }
   updateLastSeen.run(new Date().toISOString(), body.id);
+  return { found: true };
 }
 
 function handleSetSummary(body: SetSummaryRequest): void {
@@ -161,8 +210,13 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
   let peers: Peer[];
 
   switch (body.scope) {
-    case "machine":
+    case "network":
+      // All peers across all machines
       peers = selectAllPeers.all() as Peer[];
+      break;
+    case "machine":
+      // Only peers on the same hostname
+      peers = selectPeersByHostname.all(body.hostname || "localhost") as Peer[];
       break;
     case "directory":
       peers = selectPeersByDirectory.all(body.cwd) as Peer[];
@@ -184,16 +238,14 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
     peers = peers.filter((p) => p.id !== body.exclude_id);
   }
 
-  // Verify each peer's process is still alive
+  // Filter out stale peers (heartbeat-based, works cross-machine)
+  const cutoff = new Date(Date.now() - HEARTBEAT_TIMEOUT_MS).toISOString();
   return peers.filter((p) => {
-    try {
-      process.kill(p.pid, 0);
-      return true;
-    } catch {
-      // Clean up dead peer
+    if (p.last_seen < cutoff) {
       deletePeer.run(p.id);
       return false;
     }
+    return true;
   });
 }
 
@@ -227,7 +279,7 @@ function handleUnregister(body: { id: string }): void {
 
 Bun.serve({
   port: PORT,
-  hostname: "127.0.0.1",
+  hostname: HOST,
   async fetch(req) {
     const url = new URL(req.url);
     const path = url.pathname;
@@ -239,15 +291,20 @@ Bun.serve({
       return new Response("claude-peers broker", { status: 200 });
     }
 
+    // Auth check on all POST routes
+    const authErr = checkAuth(req);
+    if (authErr) return authErr;
+
     try {
       const body = await req.json();
 
       switch (path) {
         case "/register":
           return Response.json(handleRegister(body as RegisterRequest));
-        case "/heartbeat":
-          handleHeartbeat(body as HeartbeatRequest);
-          return Response.json({ ok: true });
+        case "/heartbeat": {
+          const hb = handleHeartbeat(body as HeartbeatRequest);
+          return Response.json({ ok: true, ...hb });
+        }
         case "/set-summary":
           handleSetSummary(body as SetSummaryRequest);
           return Response.json({ ok: true });
@@ -270,4 +327,4 @@ Bun.serve({
   },
 });
 
-console.error(`[claude-peers broker] listening on 127.0.0.1:${PORT} (db: ${DB_PATH})`);
+console.error(`[claude-peers broker] listening on ${HOST}:${PORT} (db: ${DB_PATH})`);

--- a/cli.ts
+++ b/cli.ts
@@ -97,7 +97,7 @@ switch (cmd) {
         }>
       >("/list-peers", {
         scope: useNetwork ? "network" : "machine",
-        hostname: (await import("os")).hostname(),
+        hostname: HOSTNAME,
         cwd: "/",
         git_root: null,
       });

--- a/cli.ts
+++ b/cli.ts
@@ -6,22 +6,28 @@
  *
  * Usage:
  *   bun cli.ts status          — Show broker status and all peers
- *   bun cli.ts peers           — List all peers
+ *   bun cli.ts peers           — List all peers (use --network for cross-machine)
  *   bun cli.ts send <id> <msg> — Send a message to a peer
  *   bun cli.ts kill-broker     — Stop the broker daemon
+ *
+ * Environment:
+ *   CLAUDE_PEERS_URL   — Broker URL (default: http://127.0.0.1:7899)
+ *   CLAUDE_PEERS_PORT  — Broker port (default: 7899, ignored if URL is set)
+ *   CLAUDE_PEERS_TOKEN — Bearer token for auth
  */
 
 const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
-const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
+const BROKER_URL = process.env.CLAUDE_PEERS_URL ?? `http://127.0.0.1:${BROKER_PORT}`;
+const AUTH_TOKEN = process.env.CLAUDE_PEERS_TOKEN ?? "";
 
 async function brokerFetch<T>(path: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (body) headers["Content-Type"] = "application/json";
+  if (AUTH_TOKEN) headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
+
   const opts: RequestInit = body
-    ? {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      }
-    : {};
+    ? { method: "POST", headers, body: JSON.stringify(body) }
+    : { headers };
   const res = await fetch(`${BROKER_URL}${path}`, {
     ...opts,
     signal: AbortSignal.timeout(3000),
@@ -46,6 +52,7 @@ switch (cmd) {
           Array<{
             id: string;
             pid: number;
+            hostname: string;
             cwd: string;
             git_root: string | null;
             tty: string | null;
@@ -53,14 +60,15 @@ switch (cmd) {
             last_seen: string;
           }>
         >("/list-peers", {
-          scope: "machine",
+          scope: "network",
+          hostname: (await import("os")).hostname(),
           cwd: "/",
           git_root: null,
         });
 
         console.log("\nPeers:");
         for (const p of peers) {
-          console.log(`  ${p.id}  PID:${p.pid}  ${p.cwd}`);
+          console.log(`  ${p.id}  ${p.hostname}  PID:${p.pid}  ${p.cwd}`);
           if (p.summary) console.log(`         ${p.summary}`);
           if (p.tty) console.log(`         TTY: ${p.tty}`);
           console.log(`         Last seen: ${p.last_seen}`);
@@ -73,11 +81,13 @@ switch (cmd) {
   }
 
   case "peers": {
+    const useNetwork = process.argv.includes("--network");
     try {
       const peers = await brokerFetch<
         Array<{
           id: string;
           pid: number;
+          hostname: string;
           cwd: string;
           git_root: string | null;
           tty: string | null;
@@ -85,7 +95,8 @@ switch (cmd) {
           last_seen: string;
         }>
       >("/list-peers", {
-        scope: "machine",
+        scope: useNetwork ? "network" : "machine",
+        hostname: (await import("os")).hostname(),
         cwd: "/",
         git_root: null,
       });
@@ -94,7 +105,7 @@ switch (cmd) {
         console.log("No peers registered.");
       } else {
         for (const p of peers) {
-          const parts = [`${p.id}  PID:${p.pid}  ${p.cwd}`];
+          const parts = [`${p.id}  ${p.hostname}  PID:${p.pid}  ${p.cwd}`];
           if (p.summary) parts.push(`  Summary: ${p.summary}`);
           console.log(parts.join("\n"));
         }
@@ -154,8 +165,12 @@ switch (cmd) {
     console.log(`claude-peers CLI
 
 Usage:
-  bun cli.ts status          Show broker status and all peers
-  bun cli.ts peers           List all peers
-  bun cli.ts send <id> <msg> Send a message to a peer
-  bun cli.ts kill-broker     Stop the broker daemon`);
+  bun cli.ts status              Show broker status and all peers
+  bun cli.ts peers [--network]   List peers (--network for cross-machine)
+  bun cli.ts send <id> <msg>     Send a message to a peer
+  bun cli.ts kill-broker         Stop the broker daemon
+
+Environment:
+  CLAUDE_PEERS_URL    Broker URL (default: http://127.0.0.1:7899)
+  CLAUDE_PEERS_TOKEN  Bearer token for authenticated brokers`);
 }

--- a/cli.ts
+++ b/cli.ts
@@ -19,6 +19,7 @@
 const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = process.env.CLAUDE_PEERS_URL ?? `http://127.0.0.1:${BROKER_PORT}`;
 const AUTH_TOKEN = process.env.CLAUDE_PEERS_TOKEN ?? "";
+const HOSTNAME = process.env.CLAUDE_PEERS_HOSTNAME ?? (await import("os")).hostname();
 
 async function brokerFetch<T>(path: string, body?: unknown): Promise<T> {
   const headers: Record<string, string> = {};
@@ -61,7 +62,7 @@ switch (cmd) {
           }>
         >("/list-peers", {
           scope: "network",
-          hostname: (await import("os")).hostname(),
+          hostname: HOSTNAME,
           cwd: "/",
           git_root: null,
         });
@@ -141,11 +142,17 @@ switch (cmd) {
   }
 
   case "kill-broker": {
+    // Only kill local brokers — can't signal remote processes
+    const brokerUrl = new URL(BROKER_URL);
+    if (brokerUrl.hostname !== "127.0.0.1" && brokerUrl.hostname !== "localhost") {
+      console.error(`Cannot kill remote broker at ${BROKER_URL}. Only local brokers can be stopped.`);
+      process.exit(1);
+    }
     try {
       const health = await brokerFetch<{ status: string; peers: number }>("/health");
       console.log(`Broker has ${health.peers} peer(s). Shutting down...`);
-      // Find and kill the broker process on the port
-      const proc = Bun.spawnSync(["lsof", "-ti", `:${BROKER_PORT}`]);
+      const port = brokerUrl.port || "7899";
+      const proc = Bun.spawnSync(["lsof", "-ti", `:${port}`]);
       const pids = new TextDecoder()
         .decode(proc.stdout)
         .trim()

--- a/client.ts
+++ b/client.ts
@@ -1,0 +1,302 @@
+/**
+ * claude-peers client SDK
+ *
+ * Framework-agnostic client for the claude-peers broker.
+ * Works with any Node.js/Bun agent: OpenClaw, LangChain, CrewAI, or plain scripts.
+ *
+ * Usage:
+ *   import { PeersClient } from './client.ts';
+ *
+ *   const peers = new PeersClient({
+ *     brokerUrl: 'http://broker:7899',
+ *     token: 'your-auth-token',
+ *     hostname: 'my-machine',
+ *     summary: 'Research agent working on market analysis',
+ *   });
+ *
+ *   await peers.register({ cwd: '/workspace', gitRoot: null });
+ *   const others = await peers.listPeers('network');
+ *   const repomates = await peers.listPeers('repo', { gitRoot: '/path/to/repo' });
+ *   await peers.sendMessage(others[0].id, 'Hey, what are you working on?');
+ *   const messages = await peers.pollMessages();
+ *
+ *   // Auto-heartbeat keeps your registration alive
+ *   peers.startHeartbeat();
+ *
+ *   // Auto-poll checks for messages on an interval and calls your handler
+ *   peers.startPolling((msg) => {
+ *     console.log(`Message from ${msg.from_id}: ${msg.text}`);
+ *   });
+ *
+ *   // Clean up on exit
+ *   peers.shutdown();
+ */
+
+import * as os from "node:os";
+
+// --- Types ---
+
+export interface Peer {
+  id: string;
+  pid: number;
+  hostname: string;
+  cwd: string;
+  git_root: string | null;
+  tty: string | null;
+  summary: string;
+  registered_at: string;
+  last_seen: string;
+}
+
+export interface Message {
+  id: number;
+  from_id: string;
+  to_id: string;
+  text: string;
+  sent_at: string;
+  delivered: boolean;
+}
+
+export interface PeersClientOptions {
+  /** Broker URL (e.g., http://localhost:7899 or http://broker.cluster:7899) */
+  brokerUrl: string;
+  /** Auth token (required if broker has CLAUDE_PEERS_TOKEN set) */
+  token?: string;
+  /** Hostname for this peer (defaults to os.hostname()) */
+  hostname?: string;
+  /** Summary of what this agent is doing (visible to other peers) */
+  summary?: string;
+  /** Heartbeat interval in ms (default: 15000) */
+  heartbeatIntervalMs?: number;
+  /** Poll interval in ms (default: 2000) */
+  pollIntervalMs?: number;
+}
+
+export interface RegisterOptions {
+  /** Working directory */
+  cwd: string;
+  /** Git root directory (null if not in a git repo) */
+  gitRoot?: string | null;
+  /** TTY (null for non-interactive agents) */
+  tty?: string | null;
+  /** PID (defaults to process.pid) */
+  pid?: number;
+}
+
+// --- Client ---
+
+export class PeersClient {
+  private brokerUrl: string;
+  private token: string;
+  private hostname: string;
+  private summary: string;
+  private heartbeatMs: number;
+  private pollMs: number;
+
+  private peerId: string | null = null;
+  private lastRegisterOpts: RegisterOptions | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: PeersClientOptions) {
+    this.brokerUrl = options.brokerUrl.replace(/\/$/, "");
+    this.token = options.token ?? "";
+    this.hostname = options.hostname ?? os.hostname();
+    this.summary = options.summary ?? "";
+    this.heartbeatMs = options.heartbeatIntervalMs ?? 15_000;
+    this.pollMs = options.pollIntervalMs ?? 2_000;
+  }
+
+  // --- Core API ---
+
+  /**
+   * Register this agent as a peer. Must be called before any other method.
+   * Returns the assigned peer ID.
+   */
+  async register(opts: RegisterOptions): Promise<string> {
+    this.lastRegisterOpts = opts;
+    const res = await this.post<{ id: string }>("/register", {
+      pid: opts.pid ?? process.pid,
+      hostname: this.hostname,
+      cwd: opts.cwd,
+      git_root: opts.gitRoot ?? null,
+      tty: opts.tty ?? null,
+      summary: this.summary,
+    });
+    this.peerId = res.id;
+    return res.id;
+  }
+
+  /**
+   * List peers. Scope controls what you see:
+   *   - 'machine' — same hostname only
+   *   - 'directory' — same working directory (pass cwd in options)
+   *   - 'repo' — same git repository (pass gitRoot in options)
+   *   - 'network' — all peers across all machines
+   */
+  async listPeers(
+    scope: "machine" | "directory" | "repo" | "network" = "network",
+    options?: { cwd?: string; gitRoot?: string | null },
+  ): Promise<Peer[]> {
+    return this.post<Peer[]>("/list-peers", {
+      scope,
+      hostname: this.hostname,
+      cwd: options?.cwd ?? "/",
+      git_root: options?.gitRoot ?? null,
+      exclude_id: this.peerId,
+    });
+  }
+
+  /** Send a message to another peer by ID. */
+  async sendMessage(toId: string, text: string): Promise<{ ok: boolean; error?: string }> {
+    this.requireRegistered();
+    return this.post("/send-message", {
+      from_id: this.peerId,
+      to_id: toId,
+      text,
+    });
+  }
+
+  /** Poll for new messages. Returns and marks them as delivered. */
+  async pollMessages(): Promise<Message[]> {
+    this.requireRegistered();
+    const res = await this.post<{ messages: Message[] }>("/poll-messages", {
+      id: this.peerId,
+    });
+    return res.messages;
+  }
+
+  /** Update your summary (visible to other peers). */
+  async setSummary(summary: string): Promise<void> {
+    this.requireRegistered();
+    this.summary = summary;
+    await this.post("/set-summary", { id: this.peerId, summary });
+  }
+
+  /** Send a heartbeat to keep your registration alive. Auto-re-registers if the broker lost the peer. */
+  async heartbeat(): Promise<void> {
+    this.requireRegistered();
+    const res = await this.post<{ found: boolean }>("/heartbeat", { id: this.peerId });
+    if (!res.found && this.lastRegisterOpts) {
+      await this.register(this.lastRegisterOpts);
+    }
+  }
+
+  /** Unregister from the broker. */
+  async unregister(): Promise<void> {
+    if (!this.peerId) return;
+    await this.post("/unregister", { id: this.peerId }).catch(() => {});
+    this.peerId = null;
+  }
+
+  /** Check if the broker is reachable. */
+  async isAlive(): Promise<boolean> {
+    try {
+      const res = await fetch(`${this.brokerUrl}/health`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  // --- Auto-heartbeat ---
+
+  /** Start automatic heartbeat (keeps registration alive). */
+  startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      this.heartbeat().catch(() => {});
+    }, this.heartbeatMs);
+  }
+
+  /** Stop automatic heartbeat. */
+  stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  // --- Auto-poll ---
+
+  /**
+   * Start polling for messages. Calls the handler for each new message.
+   * This runs in the background — messages arrive asynchronously.
+   */
+  startPolling(handler: (msg: Message) => void | Promise<void>): void {
+    this.stopPolling();
+    this.pollTimer = setInterval(async () => {
+      try {
+        const messages = await this.pollMessages();
+        for (const msg of messages) {
+          try {
+            await handler(msg);
+          } catch {
+            // Don't let handler errors crash the poll loop
+          }
+        }
+      } catch {
+        // Broker might be down temporarily
+      }
+    }, this.pollMs);
+  }
+
+  /** Stop polling for messages. */
+  stopPolling(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  // --- Lifecycle ---
+
+  /** Clean shutdown: stop timers, unregister from broker. */
+  async shutdown(): Promise<void> {
+    this.stopHeartbeat();
+    this.stopPolling();
+    await this.unregister();
+  }
+
+  /** Get the current peer ID (null if not registered). */
+  get id(): string | null {
+    return this.peerId;
+  }
+
+  /**
+   * Reconnect with a known peer ID (e.g., after broker restart).
+   * Skips registration — use when you already have a valid ID.
+   */
+  reconnect(id: string): void {
+    this.peerId = id;
+  }
+
+  // --- Internals ---
+
+  private requireRegistered(): void {
+    if (!this.peerId) {
+      throw new Error("Not registered. Call register() first.");
+    }
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.token) {
+      headers["Authorization"] = `Bearer ${this.token}`;
+    }
+    const res = await fetch(`${this.brokerUrl}${path}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.text();
+      throw new Error(`Broker error (${path}): ${res.status} ${err}`);
+    }
+    return res.json() as Promise<T>;
+  }
+}

--- a/docs/guides/chat-platform-bridge.md
+++ b/docs/guides/chat-platform-bridge.md
@@ -1,0 +1,167 @@
+# Bridging Peer Messages to Chat Platforms
+
+The claude-peers broker handles peer-to-peer messaging between agents.
+To surface these messages in Telegram, Slack, Discord, or any chat platform,
+build a bridge that polls the broker and forwards messages to your platform's
+API.
+
+This guide shows the pattern using the `PeersClient` SDK. The bridge runs
+as a background process (sidecar, systemd service, cron, etc.) alongside
+your agent.
+
+## How It Works
+
+```
+Claude Code session
+  └→ send_message [channel] text
+       └→ broker stores message
+            └→ bridge polls broker
+                 └→ posts to Telegram/Slack/Discord
+                      └→ agent sees message in chat
+                           └→ agent responds + sends reply via peers CLI
+```
+
+The bridge:
+1. Registers as a peer with the broker
+2. Polls for new messages every few seconds
+3. Parses a `[channel]` prefix to determine which chat group to post to
+4. Posts the message to the chat platform via its API
+5. Optionally triggers the agent to respond
+
+## Example Bridge
+
+This Node.js script polls the broker and posts to Telegram. Adapt for
+Slack, Discord, or any platform with an HTTP API.
+
+```javascript
+import { PeersClient } from 'claude-peers/client';
+
+// --- Config ---
+const peers = new PeersClient({
+  brokerUrl: process.env.CLAUDE_PEERS_URL,
+  token: process.env.CLAUDE_PEERS_TOKEN,
+  hostname: 'my-agent',
+  summary: 'My agent — bridged to Telegram',
+});
+
+const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+
+// Channel name → chat platform ID
+const CHANNELS = {
+  general: { chatId: '-100xxxxxxxxxx' },
+  dev:     { chatId: '-100xxxxxxxxxx' },
+};
+const DEFAULT_CHANNEL = 'general';
+
+// --- Routing ---
+function parseMessage(text) {
+  const match = text.match(/^\[([a-zA-Z0-9_-]+)\]\s*([\s\S]*)/);
+  return match
+    ? { channel: match[1].toLowerCase(), text: match[2] }
+    : { channel: DEFAULT_CHANNEL, text };
+}
+
+// --- Telegram ---
+async function sendTelegram(chatId, text) {
+  await fetch(`https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'HTML' }),
+  });
+}
+
+// --- Main ---
+await peers.register({ cwd: process.cwd() });
+peers.startHeartbeat();
+
+peers.startPolling(async (msg) => {
+  const { channel, text } = parseMessage(msg.text);
+  const target = CHANNELS[channel];
+  if (!target) {
+    console.error(`Unknown channel: ${channel}`);
+    return;
+  }
+
+  // Look up sender info
+  const allPeers = await peers.listPeers('network');
+  const sender = allPeers.find(p => p.id === msg.from_id);
+  const senderName = sender
+    ? `${sender.hostname}/${sender.summary || sender.id}`
+    : msg.from_id;
+
+  // Post to Telegram
+  const formatted = `📨 <b>Peer message from ${senderName}</b>\n\n${text}`;
+  await sendTelegram(target.chatId, formatted);
+});
+
+console.log('Bridge running — polling for messages');
+```
+
+## Adapting for Other Platforms
+
+### Slack
+
+Replace the Telegram `sendMessage` call with Slack's `chat.postMessage`:
+
+```javascript
+async function sendSlack(channel, text) {
+  await fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+    },
+    body: JSON.stringify({ channel, text }),
+  });
+}
+```
+
+### Discord
+
+Use Discord's webhook URL:
+
+```javascript
+async function sendDiscord(webhookUrl, text) {
+  await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: text }),
+  });
+}
+```
+
+## Channel Routing
+
+Messages use a `[channel-name]` prefix to target specific chat groups:
+
+```
+[dev] Hey, the build is broken — can you check?
+[general] Status update: deployment complete
+```
+
+If no prefix, messages go to the default channel. The channel map is
+configured in the bridge — map friendly names to platform-specific IDs.
+
+Only route to group channels. Never route to private/DM sessions to
+avoid hidden agent-to-agent conversations that the operator can't see.
+
+## Deployment
+
+Run the bridge alongside your agent:
+
+- **Kubernetes:** sidecar container in the agent pod
+- **Docker:** additional service in docker-compose
+- **Systemd:** background service on the agent's machine
+- **Screen/tmux:** `node bridge.js &` in a background session
+
+The bridge needs:
+- `CLAUDE_PEERS_URL` and `CLAUDE_PEERS_TOKEN` to reach the broker
+- Chat platform API token (Telegram bot token, Slack bot token, etc.)
+- Network access to both the broker and the chat platform API
+
+## Security
+
+- Route all chat platform API calls through a scanning proxy for DLP
+- Only allow group channels — block private/direct sessions
+- Make all peer messages visible to the operator in the chat platform
+- See [Pipelock Integration Guide](pipelock.md) for scanning setup

--- a/docs/guides/hardening.md
+++ b/docs/guides/hardening.md
@@ -1,0 +1,434 @@
+# Hardening Recommendations
+
+Concrete improvements to make claude-peers production-ready for multi-machine,
+multi-team deployments. Organized by area, with current state, gap, and
+proposed fix for each item.
+
+---
+
+## 1. Broker Resilience
+
+### 1a. Crash recovery and data durability
+
+**Current state:** The broker runs as a detached Bun process. If it crashes,
+all peer registrations are lost. The SQLite database survives on disk, but
+stale peer rows (with no heartbeat) are cleaned up on next start, effectively
+losing all state. Messages marked `delivered=0` survive but recipients may
+have new peer IDs after re-registering.
+
+**Gap:** No automatic restart. No WAL checkpoint on shutdown. No backup of the
+SQLite database.
+
+**Proposed fixes:**
+- Add a `SIGTERM`/`SIGINT` handler to the broker that checkpoints WAL and
+  closes the database cleanly before exiting.
+- Add a systemd unit file (and/or Docker healthcheck + restart policy) so the
+  broker restarts automatically on crash.
+- For Kubernetes, the deployment already has restart semantics, but add a
+  `preStop` lifecycle hook that sends SIGTERM and waits for graceful shutdown.
+- Consider periodic WAL checkpoints (`PRAGMA wal_checkpoint(TRUNCATE)`) on a
+  timer (e.g., every 5 minutes) to bound WAL file growth.
+- Document a backup strategy: periodic `sqlite3 .backup` to a second file, or
+  use Litestream for continuous replication.
+
+### 1b. Broker startup race condition
+
+**Current state:** `ensureBroker()` in `server.ts` launches the broker and
+polls `/health` every 200ms for up to 6 seconds. If two MCP servers start
+simultaneously, both may try to launch the broker. The second spawn's
+port-bind error is visible on stderr (inherited), but the parent process
+has no coordination or lock to prevent the race.
+
+**Gap:** No lock file or leader election. Both spawns proceed independently.
+
+**Proposed fixes:**
+- Use a lock file (`~/.claude-peers.lock`) with `flock` semantics. The first
+  process acquires the lock and spawns the broker. Others wait for the health
+  check to pass.
+- Alternatively, accept the current behavior (it works in practice since the
+  port binding is the de facto lock), but log a clear message when the spawned
+  broker exits due to port conflict.
+
+---
+
+## 2. Message Reliability
+
+### 2a. Delivery guarantees
+
+**Current state:** Messages are at-most-once. `pollMessages` marks them as
+`delivered=1` immediately on read, before the MCP channel push succeeds.
+If the channel push fails (no `--dangerously-load-development-channels`),
+the message is buffered in `pendingMessages` but also marked delivered in
+the database. If the MCP server crashes before `check_messages` drains the
+buffer, the message is lost.
+
+**Gap:** No redelivery. No acknowledgment protocol.
+
+**Proposed fixes:**
+- Change to at-least-once delivery: don't mark `delivered=1` until the client
+  explicitly acknowledges. Add an `/ack-messages` endpoint that takes a list
+  of message IDs.
+- In `pollMessages`, return undelivered messages but don't mark them. The
+  client calls `/ack-messages` after successful channel push or buffer drain.
+- Add a `delivery_attempts` counter and a maximum retry limit (e.g., 5) to
+  prevent infinite redelivery of messages to dead peers.
+- For the MCP server, acknowledge after successful channel notification or
+  after `check_messages` returns messages to Claude.
+
+### 2b. Message ordering
+
+**Current state:** Messages are ordered by `sent_at` (ISO timestamp) within a
+single recipient. Cross-peer ordering is undefined.
+
+**Gap:** No sequence numbers. Clock skew between machines can reorder messages.
+
+**Proposed fixes:**
+- Add a broker-assigned monotonic sequence number (`seq INTEGER`) to the
+  messages table. Use this instead of `sent_at` for ordering.
+- Return the sequence number in poll responses so clients can detect gaps.
+- For cross-peer total ordering (needed for group-chat-style coordination),
+  add a global sequence or vector clock. Lower priority — per-recipient
+  ordering is sufficient for most use cases.
+
+### 2c. Message size limits
+
+**Current state:** No limit on message text size. A client can send arbitrarily
+large messages, which bloats the SQLite database and could cause memory issues
+on the recipient.
+
+**Gap:** No validation on message size.
+
+**Proposed fix:**
+- Add a configurable `MAX_MESSAGE_SIZE` (default: 64KB). Reject messages over
+  the limit with HTTP 413.
+- Consider a separate `MAX_PENDING_MESSAGES` per recipient (default: 1000) to
+  prevent mailbox flooding.
+
+---
+
+## 3. Authentication and Identity
+
+### 3a. Per-peer identity
+
+**Current state:** The bearer token is shared across all clients. Any client
+with the token can impersonate any hostname and read messages addressed to any
+peer ID it can guess (since `poll-messages` only requires the peer ID, not
+proof of ownership).
+
+**Gap:** No per-peer authentication. Peer IDs are 8-char random strings — not
+cryptographically strong and vulnerable to enumeration.
+
+**Proposed fixes:**
+- **Short term:** Extend peer IDs to 32 characters (128 bits of entropy) to
+  make enumeration infeasible. Return a `secret` alongside the `id` on
+  registration. Require the secret on `/poll-messages`, `/set-summary`,
+  `/heartbeat`, and `/unregister`.
+- **Medium term:** Issue per-peer JWTs on registration. The JWT contains the
+  peer ID as a claim. All peer-specific endpoints validate the JWT. This
+  prevents a compromised peer from accessing other peers' messages.
+- **Long term:** Support mutual TLS or OIDC for peer authentication, allowing
+  integration with existing identity providers.
+
+### 3b. Peer ID collision
+
+**Current state:** `generateId()` produces 8-character alphanumeric strings
+(36^8 = ~2.8 trillion combinations). No collision check on registration.
+
+**Gap:** With enough peers over time, collisions become possible. A collision
+causes the new registration to fail (SQLite `PRIMARY KEY` constraint).
+
+**Proposed fix:**
+- Check for ID existence before inserting. Retry with a new ID on collision.
+- Increase ID length to 16+ characters.
+- Use `crypto.randomUUID()` for guaranteed uniqueness.
+
+---
+
+## 4. Rate Limiting
+
+### 4a. Broker endpoint rate limiting
+
+**Current state:** No rate limiting on any broker endpoint. A misbehaving
+client can flood the broker with requests, consuming CPU and filling the
+database.
+
+**Gap:** Denial of service risk, especially with network-exposed brokers.
+
+**Proposed fixes:**
+- Add per-IP rate limiting on all POST endpoints. Suggested defaults:
+  - `/register`: 10/min per IP (prevent registration spam)
+  - `/send-message`: 60/min per peer (prevent message flooding)
+  - `/poll-messages`: 120/min per peer (1 poll/sec is normal)
+  - `/heartbeat`: 10/min per peer (1 every 15s is normal)
+  - `/list-peers`: 30/min per peer
+- Implement with a simple in-memory sliding window (no external dependency).
+- Return HTTP 429 with `Retry-After` header when rate exceeded.
+- For Kubernetes/Docker deployments, also consider ingress-level rate limiting
+  as a defense-in-depth measure.
+
+### 4b. Registration spam
+
+**Current state:** Any authenticated client can register unlimited peers.
+Each registration creates a new row. There's no limit on peers per IP or
+per hostname.
+
+**Gap:** An attacker with a valid token can create millions of peer entries.
+
+**Proposed fix:**
+- Add a configurable `MAX_PEERS_PER_HOSTNAME` (default: 50). Reject new
+  registrations from a hostname that has reached the limit.
+- Add a global `MAX_TOTAL_PEERS` (default: 10,000) as a safety cap.
+
+---
+
+## 5. Message TTL and Cleanup
+
+### 5a. Old message cleanup
+
+**Current state:** Delivered messages (`delivered=1`) stay in the database
+forever. Undelivered messages for dead peers are deleted when the peer is
+cleaned up, but delivered messages accumulate without bound.
+
+**Gap:** Unbounded database growth. Over weeks/months, the messages table
+grows indefinitely.
+
+**Proposed fixes:**
+- Add a `CLAUDE_PEERS_MESSAGE_TTL` env var (default: 24 hours). Run a
+  periodic cleanup (e.g., every 10 minutes) that deletes messages older
+  than the TTL.
+- For delivered messages, a shorter TTL is fine (e.g., 1 hour).
+- For undelivered messages, keep them longer (up to the TTL) in case the
+  recipient restarts and re-registers.
+- Add a `VACUUM` after bulk deletes to reclaim disk space, or use
+  `auto_vacuum=INCREMENTAL` mode.
+
+### 5b. Database size monitoring
+
+**Current state:** No visibility into database size or row counts.
+
+**Gap:** Operators can't tell when the database is growing too large.
+
+**Proposed fix:**
+- Extend the `/health` endpoint to include `db_size_bytes`,
+  `total_messages`, `undelivered_messages`, and `total_peers`.
+- Add Prometheus metrics export (optional, via a `/metrics` endpoint) for
+  integration with monitoring stacks.
+
+---
+
+## 6. Persistent Peer IDs
+
+### 6a. Stable identity across restarts
+
+**Current state:** Every time a Claude Code session starts, it gets a new
+random peer ID. Other peers that had the old ID can no longer reach it.
+The heartbeat auto-re-register also assigns a new ID.
+
+**Gap:** No continuity of identity. Other peers' references to a peer ID
+become stale every time the session restarts.
+
+**Proposed fixes:**
+- **Reconnect token (recommended):** On registration, the broker returns a
+  secret reconnect token alongside the peer ID. The MCP server stores both
+  in its process memory (not a file — each process gets its own). When
+  heartbeat returns `found: false`, the client presents the token to reclaim
+  the same ID instead of getting a new one. The token is per-registration,
+  so concurrent sessions each have their own.
+- **Stored ID (agents only):** Long-running agents (not Claude Code sessions)
+  can store their peer ID in a per-process state file. The path must be
+  unique per process (e.g., include PID or a random suffix). Not suitable
+  for Claude Code sessions where multiple instances share a filesystem.
+- **Note:** Avoid deterministic IDs based on hostname+cwd — multiple
+  concurrent sessions from the same directory would collapse into one
+  identity, breaking the core multi-session use case.
+
+---
+
+## 7. Message Encryption
+
+### 7a. End-to-end encryption between peers
+
+**Current state:** Messages are stored in plaintext in the SQLite database.
+The bearer token protects transport (who can connect), but the broker operator
+and anyone with database access can read all messages.
+
+**Gap:** No confidentiality at rest. No end-to-end encryption.
+
+**Proposed fixes:**
+- **Phase 1 (encrypt at rest):** Encrypt the SQLite database using SQLCipher
+  or Bun's built-in SQLite encryption (if available). This protects against
+  disk-level access but not a compromised broker process.
+- **Phase 2 (end-to-end):** Implement peer-to-peer key exchange:
+  1. Each peer generates an X25519 keypair on registration.
+  2. The public key is stored in the `peers` table (new column).
+  3. Before sending, the sender fetches the recipient's public key via
+     `list-peers`, derives a shared secret (ECDH), and encrypts the
+     message with AES-256-GCM.
+  4. The broker stores ciphertext. Only the recipient can decrypt.
+  5. Key rotation happens on re-registration (new keypair each session).
+- **Tradeoff:** E2E encryption means the broker can't scan message content
+  for DLP or injection (Layer 2 scanning becomes ineffective). The pipelock
+  MCP proxy (Layer 1) still scans plaintext before encryption. Document this
+  tradeoff explicitly.
+
+---
+
+## 8. Health Monitoring and Alerting
+
+### 8a. Broker health checks
+
+**Current state:** The `/health` endpoint returns `{ status: "ok", peers: N }`.
+No deeper health information.
+
+**Gap:** No way to detect degraded state (e.g., database locked, high message
+backlog, stale peers not being cleaned).
+
+**Proposed fixes:**
+- Extend `/health` to include:
+  - `uptime_seconds`: broker process uptime
+  - `db_size_bytes`: SQLite file size
+  - `total_peers`: current peer count
+  - `total_messages`: total messages in database
+  - `undelivered_messages`: messages waiting for delivery
+  - `oldest_undelivered_age_seconds`: how long the oldest pending message
+    has been waiting (indicates stuck/dead peers)
+  - `last_cleanup_at`: timestamp of last stale-peer cleanup
+- Add a `/metrics` endpoint with Prometheus-format output for integration
+  with Grafana, Datadog, etc.
+
+### 8b. Peer liveness visibility
+
+**Current state:** Stale peers are silently cleaned up. No notification to
+anyone.
+
+**Gap:** If a critical peer goes offline, other peers only discover it when
+they try to send a message and it fails.
+
+**Proposed fixes:**
+- Add an optional webhook (`CLAUDE_PEERS_WEBHOOK_URL`) that fires when a
+  peer goes offline (cleaned up by heartbeat timeout).
+- Include the peer's hostname, cwd, summary, and last_seen in the webhook
+  payload.
+- This enables external alerting (PagerDuty, Slack, etc.) when important
+  peers drop.
+
+---
+
+## 9. Client SDK Improvements
+
+### 9a. Connection pooling and keep-alive
+
+**Current state:** Every `brokerFetch` call in both `client.ts` and
+`server.ts` creates a new `fetch()` request. Bun's fetch handles
+keep-alive at the HTTP level, but there's no explicit connection pooling
+or retry logic.
+
+**Gap:** Under high message volume, the broker gets hammered with new
+connections. No retry on transient failures (network blips, broker restart).
+
+**Proposed fixes:**
+- Add exponential backoff retry to `post()` in `client.ts` (3 attempts,
+  100ms/500ms/2000ms delays). Only retry on 5xx or network errors, not
+  4xx.
+- Add a circuit breaker: if 5 consecutive requests fail, stop polling for
+  30 seconds before retrying. This prevents thundering herd when the broker
+  is down.
+- Add request timeout to all broker calls (currently only `isAlive` has a
+  3-second timeout). Suggested: 5 seconds for all endpoints.
+
+### 9b. Reconnection logic
+
+**Current state:** The heartbeat handler in both `client.ts` and `server.ts`
+re-registers when the broker reports `found: false`. But if the broker itself
+is unreachable (network error), the heartbeat silently catches and ignores
+the error.
+
+**Gap:** Extended broker downtime means the client silently loses registration
+with no recovery attempt beyond the next heartbeat interval.
+
+**Proposed fix:**
+- Track consecutive heartbeat failures. After N failures (e.g., 3), log a
+  warning and increase heartbeat frequency temporarily (backoff then recover).
+- On re-registration, re-send the current summary and re-announce to any
+  known peers.
+
+### 9c. TypeScript package publishing
+
+**Current state:** The client SDK is imported via relative path
+(`./client.ts`). No npm/JSR package.
+
+**Gap:** Non-trivial to use from external projects.
+
+**Proposed fix:**
+- Publish to npm as `claude-peers` (or `@claude-peers/client`).
+- Export `PeersClient`, types, and the broker launcher as separate entry
+  points.
+
+---
+
+## 10. Bridge Improvements
+
+### 10a. Error handling and retry
+
+**Current state:** `PeersClient.startPolling()` in `client.ts` wraps the
+handler in a try/catch that silently swallows errors. If the platform API
+call fails inside the handler, the message is marked as delivered but lost.
+
+**Gap:** No retry on platform API failures. No dead letter queue.
+
+**Proposed fixes:**
+- Add retry logic to platform API calls (3 attempts with exponential
+  backoff).
+- If all retries fail, write the message to a local dead letter file
+  (`~/.claude-peers-dead-letters.jsonl`) with timestamp, destination,
+  and error.
+- Add a CLI command to replay dead letters: `bun cli.ts replay-dead-letters`.
+- For the poll loop itself, distinguish between broker errors (retry) and
+  handler errors (log + continue).
+
+### 10b. Bidirectional bridging
+
+**Current state:** The bridge example is one-way: peer messages go to chat
+platforms. There's no reverse path (chat platform messages routed back to
+peers).
+
+**Gap:** Users in Telegram/Slack can't reply to peer messages.
+
+**Proposed fix:**
+- Add a webhook receiver (or long-poll listener) for each chat platform.
+- When a user replies in the chat platform, the bridge sends a message
+  back to the originating peer via `sendMessage`.
+- Use a reply mapping (message ID -> peer ID) to route replies correctly.
+- This turns the bridge into a full duplex communication channel.
+
+### 10c. Bridge as a standalone package
+
+**Current state:** The bridge is a code example in a docs guide. No
+runnable implementation.
+
+**Gap:** Every user has to implement their own bridge.
+
+**Proposed fix:**
+- Create `bridge.ts` in the repo as a reference implementation.
+- Support Telegram, Slack, and Discord via environment variables (select
+  platform via `CLAUDE_PEERS_BRIDGE_PLATFORM`).
+- Include Dockerfile and docker-compose service definition.
+
+---
+
+## Priority Order
+
+Recommended implementation sequence based on impact and effort:
+
+1. **Message TTL / cleanup** (5a) — prevents unbounded growth, low effort
+2. **Message size limits** (2c) — prevents abuse, trivial to add
+3. **Rate limiting** (4a, 4b) — required for any network-exposed broker
+4. **Graceful shutdown** (1a) — WAL checkpoint + signal handler, low effort
+5. **Per-peer secrets** (3a short term) — 32-char IDs + registration secret
+6. **Delivery acknowledgment** (2a) — at-least-once semantics
+7. **Extended health endpoint** (8a) — monitoring visibility
+8. **Client retry/circuit breaker** (9a) — resilience under broker failures
+9. **Persistent peer IDs** (6a) — stable identity across restarts
+10. **Bridge retry + dead letter** (10a) — message durability for bridges
+11. **E2E encryption** (7a) — confidentiality, higher effort
+12. **Peer offline webhooks** (8b) — alerting integration

--- a/docs/guides/pipelock.md
+++ b/docs/guides/pipelock.md
@@ -1,0 +1,77 @@
+# Scanning Peer Messages with Pipelock
+
+[Pipelock](https://github.com/luckyPipewrench/pipelock) is an agent firewall
+that scans MCP traffic for secret exfiltration and prompt injection. Wrapping
+the claude-peers MCP server through pipelock adds automatic scanning to all
+peer messages — outbound messages are checked for leaked secrets, inbound
+messages are checked for injection attempts.
+
+## Setup
+
+Wrap the MCP server when registering with Claude Code:
+
+```bash
+claude mcp add claude-peers -- \
+  pipelock mcp proxy --config pipelock.yaml -- \
+  bun ~/claude-peers-mcp/server.ts
+```
+
+Or in `.claude.json`:
+
+```json
+{
+  "claude-peers": {
+    "type": "stdio",
+    "command": "pipelock",
+    "args": [
+      "mcp", "proxy",
+      "--config", "pipelock.yaml",
+      "--env", "CLAUDE_PEERS_URL",
+      "--env", "CLAUDE_PEERS_TOKEN",
+      "--",
+      "bun", "server.ts"
+    ],
+    "env": {
+      "CLAUDE_PEERS_URL": "http://broker-host:7899",
+      "CLAUDE_PEERS_TOKEN": "your-token"
+    }
+  }
+}
+```
+
+Use `--env` flags to pass broker credentials through to the MCP server.
+
+## Example Config
+
+```yaml
+# pipelock.yaml
+mode: balanced
+enforce: true
+
+dlp:
+  action: block
+
+response_scanning:
+  action: warn
+
+mcp_input_scanning:
+  enabled: true
+  action: block
+
+mcp_tool_scanning:
+  enabled: true
+  action: block
+```
+
+## What Gets Scanned
+
+| Direction | Tool | Scanning |
+|-----------|------|----------|
+| Outbound | `send_message` | DLP checks message text for secrets |
+| Inbound | `check_messages` | Injection detection on received messages |
+| Startup | `list_peers` | Tool definition integrity check |
+
+## Learn More
+
+- [Pipelock documentation](https://pipelab.org/pipelock/)
+- [Pipelock GitHub](https://github.com/luckyPipewrench/pipelock)

--- a/docs/guides/pipelock.md
+++ b/docs/guides/pipelock.md
@@ -7,6 +7,30 @@ Peer-to-peer messages between AI agents carry natural language that could
 contain leaked secrets (API keys, credentials) or injection payloads. Pipelock
 scans this traffic at multiple layers depending on your deployment.
 
+Pipelock is optional — claude-peers works without it. Add scanning where
+you need it: broker-side (Layer 2) requires no user install, client-side
+(Layer 1) requires pipelock on each machine.
+
+## Install
+
+**Broker side (Layer 2):** No install needed. The pipelock-enhanced
+deployment examples (`broker-with-pipelock.yaml`, `docker-compose-with-pipelock.yaml`)
+include pipelock as a container sidecar.
+
+**Client side (Layer 1, Layer 3):** Install pipelock on each machine:
+
+```bash
+# macOS
+brew install luckyPipewrench/tap/pipelock
+
+# Linux
+curl -L https://github.com/luckyPipewrench/pipelock/releases/latest/download/pipelock_linux_amd64.tar.gz | tar xz
+sudo mv pipelock /usr/local/bin/
+
+# Verify
+pipelock --version
+```
+
 ## Layer 1: MCP Proxy (Claude Code sessions)
 
 Wrap the claude-peers MCP server through pipelock. Every tool call is scanned:

--- a/docs/guides/pipelock.md
+++ b/docs/guides/pipelock.md
@@ -1,18 +1,22 @@
 # Scanning Peer Messages with Pipelock
 
 [Pipelock](https://github.com/luckyPipewrench/pipelock) is an agent firewall
-that scans MCP traffic for secret exfiltration and prompt injection. Wrapping
-the claude-peers MCP server through pipelock adds automatic scanning to all
-peer messages — outbound messages are checked for leaked secrets, inbound
-messages are checked for injection attempts.
+that scans HTTP and MCP traffic for secret exfiltration and prompt injection.
 
-## Setup
+Peer-to-peer messages between AI agents carry natural language that could
+contain leaked secrets (API keys, credentials) or injection payloads. Pipelock
+scans this traffic at multiple layers depending on your deployment.
 
-Wrap the MCP server when registering with Claude Code:
+## Layer 1: MCP Proxy (Claude Code sessions)
+
+Wrap the claude-peers MCP server through pipelock. Every tool call is scanned:
+outbound `send_message` text is checked for secrets, inbound `check_messages`
+results are checked for injection.
 
 ```bash
 claude mcp add claude-peers -- \
-  pipelock mcp proxy --config pipelock.yaml -- \
+  pipelock mcp proxy --config pipelock.yaml \
+  --env CLAUDE_PEERS_URL --env CLAUDE_PEERS_TOKEN -- \
   bun ~/claude-peers-mcp/server.ts
 ```
 
@@ -41,35 +45,167 @@ Or in `.claude.json`:
 
 Use `--env` flags to pass broker credentials through to the MCP server.
 
-## Example Config
+### MCP Config
 
 ```yaml
-# pipelock.yaml
+# pipelock.yaml — MCP proxy scanning
 mode: balanced
 enforce: true
 
-dlp:
-  action: block
-
-response_scanning:
-  action: warn
-
+# Scan tool call arguments (send_message text)
 mcp_input_scanning:
   enabled: true
   action: block
 
+# Scan tool results (check_messages responses)
+response_scanning:
+  action: warn
+
+# Detect tool definition poisoning
 mcp_tool_scanning:
   enabled: true
   action: block
 ```
 
-## What Gets Scanned
+### What Gets Scanned
 
 | Direction | Tool | Scanning |
 |-----------|------|----------|
 | Outbound | `send_message` | DLP checks message text for secrets |
 | Inbound | `check_messages` | Injection detection on received messages |
 | Startup | `list_peers` | Tool definition integrity check |
+
+## Layer 2: Reverse Proxy (Broker)
+
+Run pipelock as a sidecar in front of the broker. All HTTP POST bodies
+(message text, registration data) are scanned for DLP patterns before
+reaching the broker.
+
+This catches secrets from any client — not just pipelock-wrapped ones.
+
+### Kubernetes
+
+```yaml
+containers:
+  - name: pipelock
+    image: ghcr.io/luckypipewrench/pipelock:latest
+    args:
+      - "run"
+      - "--listen=127.0.0.1:18888"
+      - "--reverse-proxy"
+      - "--reverse-upstream=http://127.0.0.1:7899"
+      - "--reverse-listen=:8888"
+      - "--config=/etc/pipelock/pipelock.yaml"
+    ports:
+      - containerPort: 8888
+  - name: broker
+    image: ghcr.io/louislva/claude-peers-broker:latest
+    env:
+      - name: CLAUDE_PEERS_HOST
+        value: "127.0.0.1"  # Only accepts traffic from pipelock
+      - name: CLAUDE_PEERS_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: claude-peers-auth
+            key: token
+```
+
+Point the Service `targetPort` at pipelock (8888), not the broker (7899).
+The broker binds to localhost — all external traffic goes through pipelock.
+
+### Docker Compose
+
+```yaml
+services:
+  pipelock:
+    image: ghcr.io/luckypipewrench/pipelock:latest
+    command:
+      - "run"
+      - "--listen=127.0.0.1:18888"
+      - "--reverse-proxy"
+      - "--reverse-upstream=http://broker:7899"
+      - "--reverse-listen=:8888"
+    ports:
+      - "7899:8888"
+    volumes:
+      - ./pipelock.yaml:/etc/pipelock/pipelock.yaml:ro
+  broker:
+    build: .
+    environment:
+      CLAUDE_PEERS_HOST: "0.0.0.0"
+      CLAUDE_PEERS_TOKEN: "${CLAUDE_PEERS_TOKEN}"
+    expose:
+      - "7899"
+```
+
+### Reverse Proxy Config
+
+```yaml
+# pipelock.yaml — reverse proxy scanning
+mode: balanced
+enforce: true
+
+# Scan POST bodies for secrets
+request_body_scanning:
+  enabled: true
+  action: block
+
+# Scan responses for injection
+response_scanning:
+  action: warn
+
+# DLP patterns (includes API keys, credit cards, etc.)
+dlp:
+  scan_env: false
+  include_defaults: true
+
+# Disable unused proxy modes
+fetch_proxy:
+  enabled: false
+forward_proxy:
+  enabled: false
+```
+
+## Layer 3: HTTPS Proxy (Non-Claude agents)
+
+For agents that call the broker over HTTPS or make external API calls
+(e.g., forwarding messages to Telegram, Slack, Discord), route traffic
+through pipelock's forward proxy with TLS interception.
+
+```bash
+# Agent environment
+export HTTPS_PROXY=http://localhost:8888
+export HTTP_PROXY=http://localhost:8888
+export NODE_EXTRA_CA_CERTS=/path/to/pipelock-ca.pem  # Trust pipelock's TLS CA
+```
+
+This scans all outbound HTTPS traffic from the agent, including:
+- Broker API calls (message text in POST bodies)
+- Chat platform API calls (Telegram, Slack, Discord)
+- Any external HTTP the agent makes
+
+## Full Stack
+
+For maximum coverage, combine all three layers:
+
+```
+Claude Code session
+  └→ pipelock MCP proxy (Layer 1: DLP on tool calls)
+       └→ broker service
+            └→ pipelock reverse proxy (Layer 2: DLP on all POST bodies)
+                 └→ broker process
+
+Non-Claude agent
+  └→ pipelock HTTPS proxy (Layer 3: TLS interception + DLP)
+       └→ broker service
+            └→ pipelock reverse proxy (Layer 2: DLP on all POST bodies)
+                 └→ broker process
+```
+
+Every message is scanned at least once (Layer 2). Claude Code sessions get
+double scanning (Layer 1 + Layer 2). External agents with HTTPS proxy get
+triple scanning (Layer 3 + Layer 2 on broker, plus Layer 3 on outbound
+chat platform calls).
 
 ## Learn More
 

--- a/docs/guides/pipelock.md
+++ b/docs/guides/pipelock.md
@@ -115,18 +115,18 @@ The broker binds to localhost — all external traffic goes through pipelock.
 
 ### Docker Compose
 
+Use an internal network so only pipelock can reach the broker:
+
 ```yaml
 services:
   pipelock:
     image: ghcr.io/luckypipewrench/pipelock:latest
-    command:
-      - "run"
-      - "--listen=127.0.0.1:18888"
-      - "--reverse-proxy"
-      - "--reverse-upstream=http://broker:7899"
-      - "--reverse-listen=:8888"
+    command: ["run", "--listen=127.0.0.1:18888", "--reverse-proxy",
+      "--reverse-upstream=http://broker:7899", "--reverse-listen=:8888",
+      "--config=/etc/pipelock/pipelock.yaml"]
     ports:
       - "7899:8888"
+    networks: [public, internal]
     volumes:
       - ./pipelock.yaml:/etc/pipelock/pipelock.yaml:ro
   broker:
@@ -134,8 +134,12 @@ services:
     environment:
       CLAUDE_PEERS_HOST: "0.0.0.0"
       CLAUDE_PEERS_TOKEN: "${CLAUDE_PEERS_TOKEN}"
-    expose:
-      - "7899"
+    networks: [internal]  # Only reachable by pipelock
+
+networks:
+  public: {}
+  internal:
+    internal: true  # No external access
 ```
 
 ### Reverse Proxy Config

--- a/examples/docker/docker-compose-with-pipelock.yaml
+++ b/examples/docker/docker-compose-with-pipelock.yaml
@@ -1,6 +1,7 @@
 # claude-peers broker with pipelock security scanning
 #
 # Pipelock scans all broker traffic for secrets and injection.
+# The broker is on an internal network only pipelock can reach.
 #
 # Start: docker compose -f docker-compose-with-pipelock.yaml up -d
 # Connect: CLAUDE_PEERS_URL=http://localhost:7899 CLAUDE_PEERS_TOKEN=changeme
@@ -19,6 +20,9 @@ services:
       - "7899:8888"
     volumes:
       - ./pipelock.yaml:/etc/pipelock/pipelock.yaml:ro
+    networks:
+      - public
+      - internal
     depends_on:
       - broker
     read_only: true
@@ -33,8 +37,15 @@ services:
       CLAUDE_PEERS_TOKEN: "${CLAUDE_PEERS_TOKEN:-changeme}"
     volumes:
       - peers-data:/data
+    networks:
+      - internal  # Only reachable by pipelock, not exposed
     read_only: true
     restart: unless-stopped
+
+networks:
+  public: {}
+  internal:
+    internal: true  # No external access — only containers on this network
 
 volumes:
   peers-data:

--- a/examples/docker/docker-compose-with-pipelock.yaml
+++ b/examples/docker/docker-compose-with-pipelock.yaml
@@ -1,0 +1,40 @@
+# claude-peers broker with pipelock security scanning
+#
+# Pipelock scans all broker traffic for secrets and injection.
+#
+# Start: docker compose -f docker-compose-with-pipelock.yaml up -d
+# Connect: CLAUDE_PEERS_URL=http://localhost:7899 CLAUDE_PEERS_TOKEN=changeme
+
+services:
+  pipelock:
+    image: ghcr.io/luckypipewrench/pipelock:latest
+    command:
+      - "run"
+      - "--listen=127.0.0.1:18888"
+      - "--reverse-proxy"
+      - "--reverse-upstream=http://broker:7899"
+      - "--reverse-listen=:8888"
+      - "--config=/etc/pipelock/pipelock.yaml"
+    ports:
+      - "7899:8888"
+    volumes:
+      - ./pipelock.yaml:/etc/pipelock/pipelock.yaml:ro
+    depends_on:
+      - broker
+    read_only: true
+    restart: unless-stopped
+
+  broker:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    environment:
+      CLAUDE_PEERS_HOST: "0.0.0.0"
+      CLAUDE_PEERS_TOKEN: "${CLAUDE_PEERS_TOKEN:-changeme}"
+    volumes:
+      - peers-data:/data
+    read_only: true
+    restart: unless-stopped
+
+volumes:
+  peers-data:

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -1,0 +1,22 @@
+# claude-peers broker — Docker Compose
+#
+# Start: docker compose up -d
+# Connect: CLAUDE_PEERS_URL=http://localhost:7899 CLAUDE_PEERS_TOKEN=changeme
+
+services:
+  broker:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    ports:
+      - "7899:7899"
+    environment:
+      CLAUDE_PEERS_HOST: "0.0.0.0"
+      CLAUDE_PEERS_TOKEN: "${CLAUDE_PEERS_TOKEN:-changeme}"
+    volumes:
+      - peers-data:/data
+    restart: unless-stopped
+    read_only: true
+
+volumes:
+  peers-data:

--- a/examples/docker/pipelock.yaml
+++ b/examples/docker/pipelock.yaml
@@ -1,0 +1,25 @@
+# Pipelock config for claude-peers broker reverse proxy
+# Scans all POST bodies for secrets, responses for injection
+
+mode: balanced
+enforce: true
+
+request_body_scanning:
+  enabled: true
+  action: block
+
+response_scanning:
+  action: warn
+
+dlp:
+  scan_env: false
+  include_defaults: true
+
+fetch_proxy:
+  enabled: false
+forward_proxy:
+  enabled: false
+
+logging:
+  level: info
+  format: json

--- a/examples/kubernetes/broker-with-pipelock.yaml
+++ b/examples/kubernetes/broker-with-pipelock.yaml
@@ -1,0 +1,173 @@
+# claude-peers broker with pipelock security scanning
+#
+# Pipelock runs as a reverse proxy sidecar in front of the broker.
+# All POST bodies (message text, registration data) are scanned for
+# secret exfiltration before reaching the broker. Responses are scanned
+# for prompt injection.
+#
+# Deploy with:
+#   kubectl create namespace claude-peers
+#   kubectl create secret generic claude-peers-auth -n claude-peers --from-literal=token=YOUR_TOKEN
+#   kubectl apply -f broker-with-pipelock.yaml
+#
+# Connect from Claude Code on any machine:
+#   CLAUDE_PEERS_URL=http://<node-ip>:30789 CLAUDE_PEERS_TOKEN=YOUR_TOKEN
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipelock-config
+  namespace: claude-peers
+data:
+  pipelock.yaml: |
+    mode: balanced
+    enforce: true
+    request_body_scanning:
+      enabled: true
+      action: block
+    response_scanning:
+      action: warn
+    dlp:
+      scan_env: false
+      include_defaults: true
+    fetch_proxy:
+      enabled: false
+    forward_proxy:
+      enabled: false
+    logging:
+      level: info
+      format: json
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: claude-peers-broker
+  namespace: claude-peers
+  labels:
+    app: claude-peers-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: claude-peers-broker
+  template:
+    metadata:
+      labels:
+        app: claude-peers-broker
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        # Pipelock reverse proxy — scans all traffic before it reaches the broker
+        - name: pipelock
+          image: ghcr.io/luckypipewrench/pipelock:latest
+          args:
+            - "run"
+            - "--listen=127.0.0.1:18888"
+            - "--reverse-proxy"
+            - "--reverse-upstream=http://127.0.0.1:7899"
+            - "--reverse-listen=:8888"
+            - "--config=/etc/pipelock/pipelock.yaml"
+          ports:
+            - containerPort: 8888
+              name: proxy
+          volumeMounts:
+            - name: pipelock-config
+              mountPath: /etc/pipelock
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8888
+            initialDelaySeconds: 2
+            periodSeconds: 10
+        # Broker — only accepts traffic from pipelock (localhost)
+        - name: broker
+          image: ghcr.io/louislva/claude-peers-broker:latest
+          env:
+            - name: CLAUDE_PEERS_HOST
+              value: "127.0.0.1"
+            - name: CLAUDE_PEERS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: claude-peers-auth
+                  key: token
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: data
+          emptyDir:
+            sizeLimit: 50Mi
+        - name: pipelock-config
+          configMap:
+            name: pipelock-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: claude-peers
+  namespace: claude-peers
+spec:
+  type: NodePort
+  selector:
+    app: claude-peers-broker
+  ports:
+    - port: 7899
+      targetPort: 8888  # Routes to pipelock, not broker directly
+      nodePort: 30789
+      protocol: TCP
+      name: broker
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: claude-peers
+  namespace: claude-peers
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8888
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system

--- a/examples/kubernetes/broker.yaml
+++ b/examples/kubernetes/broker.yaml
@@ -1,0 +1,124 @@
+# claude-peers broker — Kubernetes deployment
+#
+# Deploy with:
+#   kubectl create namespace claude-peers
+#   kubectl create secret generic claude-peers-auth -n claude-peers --from-literal=token=YOUR_TOKEN
+#   kubectl apply -f broker.yaml
+#
+# Connect from Claude Code on any machine:
+#   CLAUDE_PEERS_URL=http://<node-ip>:30789 CLAUDE_PEERS_TOKEN=YOUR_TOKEN
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: claude-peers-broker
+  namespace: claude-peers
+  labels:
+    app: claude-peers-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: claude-peers-broker
+  template:
+    metadata:
+      labels:
+        app: claude-peers-broker
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: broker
+          image: ghcr.io/louislva/claude-peers-broker:latest
+          ports:
+            - containerPort: 7899
+              name: broker
+          env:
+            - name: CLAUDE_PEERS_HOST
+              value: "0.0.0.0"
+            - name: CLAUDE_PEERS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: claude-peers-auth
+                  key: token
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 7899
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 7899
+            initialDelaySeconds: 5
+            periodSeconds: 30
+      volumes:
+        - name: data
+          # emptyDir is ephemeral — data is lost on pod restart.
+          # For persistence, replace with a PVC:
+          #   persistentVolumeClaim:
+          #     claimName: claude-peers-data
+          emptyDir:
+            sizeLimit: 50Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: claude-peers
+  namespace: claude-peers
+spec:
+  type: NodePort
+  selector:
+    app: claude-peers-broker
+  ports:
+    - port: 7899
+      targetPort: 7899
+      nodePort: 30789
+      protocol: TCP
+      name: broker
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: claude-peers
+  namespace: claude-peers
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 7899
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system

--- a/index.ts
+++ b/index.ts
@@ -3,11 +3,14 @@
  *
  * Peer discovery and messaging for Claude Code instances.
  *
- * This package has two entry points:
+ * Entry points:
  *   - server.ts  — MCP server (spawned by Claude Code, one per instance)
- *   - broker.ts  — Shared broker daemon (auto-launched, one per machine)
+ *   - broker.ts  — Shared broker daemon (auto-launched or deployed separately)
+ *   - client.ts  — Framework-agnostic SDK for non-Claude agents
+ *   - cli.ts     — CLI utility for inspecting broker state
  *
  * See README.md for setup and usage.
  */
 
-export { } // module marker
+export { PeersClient } from "./client.ts";
+export type { Peer, Message, PeersClientOptions, RegisterOptions } from "./client.ts";

--- a/server.ts
+++ b/server.ts
@@ -35,17 +35,23 @@ import {
 // --- Configuration ---
 
 const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
-const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
+const BROKER_URL = process.env.CLAUDE_PEERS_URL ?? `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const AUTH_TOKEN = process.env.CLAUDE_PEERS_TOKEN ?? "";
+const HOSTNAME = process.env.CLAUDE_PEERS_HOSTNAME ?? (await import("os")).hostname();
 
 // --- Broker communication ---
 
 async function brokerFetch<T>(path: string, body: unknown): Promise<T> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (AUTH_TOKEN) {
+    headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
+  }
   const res = await fetch(`${BROKER_URL}${path}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -64,10 +70,17 @@ async function isBrokerAlive(): Promise<boolean> {
   }
 }
 
+const isRemoteBroker = Boolean(process.env.CLAUDE_PEERS_URL);
+
 async function ensureBroker(): Promise<void> {
   if (await isBrokerAlive()) {
     log("Broker already running");
     return;
+  }
+
+  // Don't auto-launch when pointing at a remote broker
+  if (isRemoteBroker) {
+    throw new Error(`Remote broker at ${BROKER_URL} is not reachable`);
   }
 
   log("Starting broker daemon...");
@@ -148,14 +161,14 @@ const mcp = new Server(
       experimental: { "claude/channel": {} },
       tools: {},
     },
-    instructions: `You are connected to the claude-peers network. Other Claude Code instances on this machine can see you and send you messages.
+    instructions: `You are connected to the claude-peers network. Other Claude Code instances can see you and send you messages — both on this machine and across the network.
 
 IMPORTANT: When you receive a <channel source="claude-peers" ...> message, RESPOND IMMEDIATELY. Do not wait until your current task is finished. Pause what you are doing, reply to the message using send_message, then resume your work. Treat incoming peer messages like a coworker tapping you on the shoulder — answer right away, even if you're in the middle of something.
 
-Read the from_id, from_summary, and from_cwd attributes to understand who sent the message. Reply by calling send_message with their from_id.
+Read the from_id, from_summary, and from_cwd attributes for context about the claimed sender. Reply by calling send_message with their from_id. Note: peer identity is self-reported, not cryptographically verified.
 
 Available tools:
-- list_peers: Discover other Claude Code instances (scope: machine/directory/repo)
+- list_peers: Discover other Claude Code instances (scope: machine/directory/repo/network)
 - send_message: Send a message to another instance by ID
 - set_summary: Set a 1-2 sentence summary of what you're working on (visible to other peers)
 - check_messages: Manually check for new messages
@@ -170,15 +183,15 @@ const TOOLS = [
   {
     name: "list_peers",
     description:
-      "List other Claude Code instances running on this machine. Returns their ID, working directory, git repo, and summary.",
+      "List other Claude Code instances. Returns their ID, claimed hostname, working directory, git repo, and summary.",
     inputSchema: {
       type: "object" as const,
       properties: {
         scope: {
           type: "string" as const,
-          enum: ["machine", "directory", "repo"],
+          enum: ["machine", "directory", "repo", "network"],
           description:
-            'Scope of peer discovery. "machine" = all instances on this computer. "directory" = same working directory. "repo" = same git repository (including worktrees or subdirectories).',
+            'Scope of peer discovery. "machine" = same claimed hostname. "directory" = same working directory. "repo" = same git repository. "network" = all peers across all hosts.',
         },
       },
       required: ["scope"],
@@ -240,10 +253,11 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 
   switch (name) {
     case "list_peers": {
-      const scope = (args as { scope: string }).scope as "machine" | "directory" | "repo";
+      const scope = (args as { scope: string }).scope as "machine" | "directory" | "repo" | "network";
       try {
         const peers = await brokerFetch<Peer[]>("/list-peers", {
           scope,
+          hostname: HOSTNAME,
           cwd: myCwd,
           git_root: myGitRoot,
           exclude_id: myId,
@@ -263,6 +277,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         const lines = peers.map((p) => {
           const parts = [
             `ID: ${p.id}`,
+            `Host: ${p.hostname}`,
             `PID: ${p.pid}`,
             `CWD: ${p.cwd}`,
           ];
@@ -363,35 +378,24 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           isError: true,
         };
       }
-      try {
-        const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
-        if (result.messages.length === 0) {
-          return {
-            content: [{ type: "text" as const, text: "No new messages." }],
-          };
-        }
-        const lines = result.messages.map(
-          (m) => `From ${m.from_id} (${m.sent_at}):\n${m.text}`
-        );
+      // Drain the buffer populated by the polling loop
+      if (pendingMessages.length === 0) {
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: `${result.messages.length} new message(s):\n\n${lines.join("\n\n---\n\n")}`,
-            },
-          ],
-        };
-      } catch (e) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Error checking messages: ${e instanceof Error ? e.message : String(e)}`,
-            },
-          ],
-          isError: true,
+          content: [{ type: "text" as const, text: "No new messages." }],
         };
       }
+      const msgs = pendingMessages.splice(0, pendingMessages.length);
+      const lines = msgs.map(
+        (m) => `From ${m.from_id}${m.from_summary ? ` (${m.from_summary})` : ""} (${m.sent_at}):\n${m.text}`
+      );
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `${msgs.length} new message(s):\n\n${lines.join("\n\n---\n\n")}`,
+          },
+        ],
+      };
     }
 
     default:
@@ -400,6 +404,9 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 });
 
 // --- Polling loop for inbound messages ---
+
+// Buffer for messages consumed by the poll loop — check_messages reads from here
+const pendingMessages: Array<Message & { from_summary?: string; from_cwd?: string }> = [];
 
 async function pollAndPushMessages() {
   if (!myId) return;
@@ -413,7 +420,8 @@ async function pollAndPushMessages() {
       let fromCwd = "";
       try {
         const peers = await brokerFetch<Peer[]>("/list-peers", {
-          scope: "machine",
+          scope: "network",
+          hostname: HOSTNAME,
           cwd: myCwd,
           git_root: myGitRoot,
         });
@@ -426,21 +434,28 @@ async function pollAndPushMessages() {
         // Non-critical, proceed without sender info
       }
 
-      // Push as channel notification — this is what makes it immediate
-      await mcp.notification({
-        method: "notifications/claude/channel",
-        params: {
-          content: msg.text,
-          meta: {
-            from_id: msg.from_id,
-            from_summary: fromSummary,
-            from_cwd: fromCwd,
-            sent_at: msg.sent_at,
+      // Try channel notification (works when --dangerously-load-development-channels is set)
+      try {
+        await mcp.notification({
+          method: "notifications/claude/channel",
+          params: {
+            content: msg.text,
+            meta: {
+              from_id: msg.from_id,
+              from_summary: fromSummary,
+              from_cwd: fromCwd,
+              sent_at: msg.sent_at,
+            },
           },
-        },
-      });
+        });
+        log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+      } catch {
+        // Channel push not available — buffer for check_messages fallback
+        log(`Buffered message from ${msg.from_id} (channel push unavailable)`);
+      }
 
-      log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+      // Always buffer — check_messages drains this
+      pendingMessages.push({ ...msg, from_summary: fromSummary, from_cwd: fromCwd });
     }
   } catch (e) {
     // Broker might be down temporarily, don't crash
@@ -490,6 +505,7 @@ async function main() {
   // 4. Register with broker
   const reg = await brokerFetch<RegisterResponse>("/register", {
     pid: process.pid,
+    hostname: HOSTNAME,
     cwd: myCwd,
     git_root: myGitRoot,
     tty,
@@ -519,13 +535,26 @@ async function main() {
   // 6. Start polling for inbound messages
   const pollTimer = setInterval(pollAndPushMessages, POLL_INTERVAL_MS);
 
-  // 7. Start heartbeat
+  // 7. Start heartbeat (auto-re-register if broker lost our registration)
   const heartbeatTimer = setInterval(async () => {
     if (myId) {
       try {
-        await brokerFetch("/heartbeat", { id: myId });
+        const res = await brokerFetch<{ found: boolean }>("/heartbeat", { id: myId });
+        if (!res.found) {
+          log("Peer registration lost — re-registering");
+          const reg = await brokerFetch<RegisterResponse>("/register", {
+            pid: process.pid,
+            hostname: HOSTNAME,
+            cwd: myCwd,
+            git_root: myGitRoot,
+            tty: getTty(),
+            summary: initialSummary,
+          });
+          myId = reg.id;
+          log(`Re-registered as peer ${myId}`);
+        }
       } catch {
-        // Non-critical
+        // Broker might be down temporarily
       }
     }
   }, HEARTBEAT_INTERVAL_MS);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4,6 +4,7 @@ export type PeerId = string;
 export interface Peer {
   id: PeerId;
   pid: number;
+  hostname: string;
   cwd: string;
   git_root: string | null;
   tty: string | null;
@@ -25,6 +26,7 @@ export interface Message {
 
 export interface RegisterRequest {
   pid: number;
+  hostname: string;
   cwd: string;
   git_root: string | null;
   tty: string | null;
@@ -45,8 +47,9 @@ export interface SetSummaryRequest {
 }
 
 export interface ListPeersRequest {
-  scope: "machine" | "directory" | "repo";
+  scope: "machine" | "directory" | "repo" | "network";
   // The requesting peer's context (used for filtering)
+  hostname: string;
   cwd: string;
   git_root: string | null;
   exclude_id?: PeerId;


### PR DESCRIPTION
Peers on different machines can discover and message each other through a shared broker. Includes a framework-agnostic client SDK, deployment manifests, chat platform bridge guide, and security scanning integration.

**Cross-machine networking:**
- `CLAUDE_PEERS_HOST` bind address, `CLAUDE_PEERS_TOKEN` bearer auth (required for non-loopback)
- `hostname` field on peers with schema migration for existing databases
- Heartbeat-based liveness replaces PID checks (PID only works locally)
- Heartbeat returns `{found: false}` for unknown peers so clients auto-re-register
- `"network"` scope for cross-machine discovery

**MCP server:**
- `CLAUDE_PEERS_URL` for remote broker, auth token forwarded on all requests
- Skips broker auto-launch when using a remote URL
- Auto-re-registers on heartbeat loss
- Trust model documented: shared token = access control, peer identity is self-reported

**Client SDK (`client.ts`):**
- `PeersClient` class for any Node.js/Bun agent — not just Claude Code
- register, listPeers, sendMessage, pollMessages, setSummary
- Auto-heartbeat, auto-poll with handlers, auto-re-register on broker loss
- `reconnect()` for resuming with a known peer ID

**Deployment:**
- Dockerfile (oven/bun:1-alpine, non-root)
- Kubernetes manifests — basic and pipelock-enhanced (reverse proxy sidecar)
- Docker Compose — basic and pipelock-enhanced (internal network isolation)

**Guides:**
- Pipelock integration: 3-layer scanning (MCP proxy, reverse proxy sidecar, HTTPS proxy), install instructions, configs for each layer
- Chat platform bridge: pattern for routing peer messages to Telegram/Slack/Discord with `[channel]` prefix, example code, deployment options
- Hardening roadmap: message TTL, rate limiting, per-peer auth, encryption, monitoring, reconnect tokens

**README:**
- Prerequisites with Bun install
- Full `.claude.json` config blocks (basic, cross-machine, pipelock-wrapped)
- Push notifications vs polling explained
- Chat platform bridge section with channel routing