### PR TITLE
Strip OpenAI, wire OpenClaw integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,24 +6,25 @@ alwaysApply: false
 
 # claude-peers
 
-Peer discovery and messaging MCP channel for Claude Code instances.
+Peer discovery and messaging MCP channel for Claude Code instances, wired into OpenClaw.
 
 ## Architecture
 
 - `broker.ts` — Singleton HTTP daemon on localhost:7899 + SQLite. Auto-launched by the MCP server.
-- `server.ts` — MCP stdio server, one per Claude Code instance. Connects to broker, exposes tools, pushes channel notifications.
+- `server.ts` — MCP stdio server, one per Claude Code instance. Connects to broker, exposes tools, pushes channel notifications. Sends events to OpenClaw.
 - `shared/types.ts` — Shared TypeScript types for broker API.
-- `shared/summarize.ts` — Auto-summary generation via gpt-5.4-nano.
+- `shared/summarize.ts` — Local auto-summary from git branch + recent files (no LLM).
 - `cli.ts` — CLI utility for inspecting broker state.
+
+## OpenClaw Integration
+
+Peer registration and summary updates fire `openclaw system event` (fire-and-forget, `next-heartbeat` mode) so OpenClaw can track all active Claude Code sessions.
 
 ## Running
 
 ```bash
-# Start Claude Code with the channel:
-claude --dangerously-load-development-channels server:claude-peers
-
-# Or just add to .mcp.json and use as regular MCP (no channel push, but tools work):
-# { "claude-peers": { "command": "bun", "args": ["./server.ts"] } }
+# MCP server (configured in ~/.claude.json, auto-starts broker):
+# { "claude-peers": { "command": "bun", "args": ["/Users/knox/Documents/Dev/claude-peers/server.ts"] } }
 
 # CLI:
 bun cli.ts status
@@ -38,104 +39,7 @@ Default to using Bun instead of Node.js.
 
 - Use `bun <file>` instead of `node <file>` or `ts-node <file>`
 - Use `bun test` instead of `jest` or `vitest`
-- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
-- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
-- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
-- Use `bunx <package> <command>` instead of `npx <package> <command>`
+- Use `bun install` instead of `npm install`
+- Use `bun run <script>` instead of `npm run <script>`
 - Bun automatically loads .env, so don't use dotenv.
-
-## APIs
-
-- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
-- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
-- `Bun.redis` for Redis. Don't use `ioredis`.
-- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
-- `WebSocket` is built-in. Don't use `ws`.
-- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
-- Bun.$`ls` instead of execa.
-
-## Testing
-
-Use `bun test` to run tests.
-
-```ts#index.test.ts
-import { test, expect } from "bun:test";
-
-test("hello world", () => {
-  expect(1).toBe(1);
-});
-```
-
-## Frontend
-
-Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
-
-Server:
-
-```ts#index.ts
-import index from "./index.html"
-
-Bun.serve({
-  routes: {
-    "/": index,
-    "/api/users/:id": {
-      GET: (req) => {
-        return new Response(JSON.stringify({ id: req.params.id }));
-      },
-    },
-  },
-  // optional websocket support
-  websocket: {
-    open: (ws) => {
-      ws.send("Hello, world!");
-    },
-    message: (ws, message) => {
-      ws.send(message);
-    },
-    close: (ws) => {
-      // handle close
-    }
-  },
-  development: {
-    hmr: true,
-    console: true,
-  }
-})
-```
-
-HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
-
-```html#index.html
-<html>
-  <body>
-    <h1>Hello, world!</h1>
-    <script type="module" src="./frontend.tsx"></script>
-  </body>
-</html>
-```
-
-With the following `frontend.tsx`:
-
-```tsx#frontend.tsx
-import React from "react";
-import { createRoot } from "react-dom/client";
-
-// import .css files directly and it works
-import './index.css';
-
-const root = createRoot(document.body);
-
-export default function Frontend() {
-  return <h1>Hello, world!</h1>;
-}
-
-root.render(<Frontend />);
-```
-
-Then, run index.ts
-
-```sh
-bun --hot ./index.ts
-```
-
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.
+- `Bun.serve()` for HTTP, `bun:sqlite` for SQLite, `Bun.file` over `node:fs`.

--- a/server.ts
+++ b/server.ts
@@ -91,6 +91,22 @@ async function ensureBroker(): Promise<void> {
   throw new Error("Failed to start broker daemon after 6 seconds");
 }
 
+// --- OpenClaw integration ---
+
+/**
+ * Fire-and-forget notification to OpenClaw so it can track peer activity.
+ * Non-critical — failures are silently ignored.
+ */
+function notifyOpenClaw(text: string) {
+  try {
+    Bun.spawn(["openclaw", "system", "event", "--text", text, "--mode", "next-heartbeat"], {
+      stdio: ["ignore", "ignore", "ignore"],
+    }).unref();
+  } catch {
+    // OpenClaw may not be running — non-critical
+  }
+}
+
 // --- Utility ---
 
 function log(msg: string) {
@@ -340,6 +356,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       }
       try {
         await brokerFetch("/set-summary", { id: myId, summary });
+        notifyOpenClaw(`Claude peer ${myId} summary: ${summary}`);
         return {
           content: [{ type: "text" as const, text: `Summary updated: "${summary}"` }],
         };
@@ -463,7 +480,7 @@ async function main() {
   log(`Git root: ${myGitRoot ?? "(none)"}`);
   log(`TTY: ${tty ?? "(unknown)"}`);
 
-  // 3. Generate initial summary via gpt-5.4-nano (non-blocking, best-effort)
+  // 3. Generate initial summary (non-blocking, best-effort)
   let initialSummary = "";
   const summaryPromise = (async () => {
     try {
@@ -497,6 +514,7 @@ async function main() {
   });
   myId = reg.id;
   log(`Registered as peer ${myId}`);
+  notifyOpenClaw(`Claude peer ${myId} registered in ${myCwd}${initialSummary ? ` — ${initialSummary}` : ""}`);
 
   // If summary generation is still running, update it when done
   if (!initialSummary) {

--- a/shared/summarize.ts
+++ b/shared/summarize.ts
@@ -1,11 +1,11 @@
 /**
- * Generate a 1-2 sentence summary of what a Claude Code instance is likely
- * working on, based on its working directory and git context.
+ * Generate a summary of what a Claude Code instance is likely working on,
+ * based on its working directory and git context.
  *
- * Uses OpenAI's gpt-5.4-nano for cheap, fast inference.
- * Requires OPENAI_API_KEY environment variable.
- * Falls back gracefully if unavailable.
+ * Pure local — no LLM calls, no API keys needed.
  */
+
+import { basename } from "node:path";
 
 export async function generateSummary(context: {
   cwd: string;
@@ -13,59 +13,19 @@ export async function generateSummary(context: {
   git_branch?: string | null;
   recent_files?: string[];
 }): Promise<string | null> {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    return null;
+  const project = basename(context.git_root ?? context.cwd);
+  const parts: string[] = [`Working on ${project}`];
+
+  if (context.git_branch && context.git_branch !== "HEAD") {
+    parts[0] += ` (${context.git_branch})`;
   }
 
-  const parts = [`Working directory: ${context.cwd}`];
-  if (context.git_root) {
-    parts.push(`Git repo root: ${context.git_root}`);
-  }
-  if (context.git_branch) {
-    parts.push(`Branch: ${context.git_branch}`);
-  }
   if (context.recent_files && context.recent_files.length > 0) {
-    parts.push(`Recently modified files: ${context.recent_files.join(", ")}`);
+    const files = context.recent_files.slice(0, 5).join(", ");
+    parts.push(`Recent files: ${files}`);
   }
 
-  try {
-    const res = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: "gpt-5.4-nano",
-        messages: [
-          {
-            role: "system",
-            content:
-              "You generate brief summaries of what a developer is working on based on their project context. Respond with exactly 1-2 sentences, no more. Be specific about the project name and likely task.",
-          },
-          {
-            role: "user",
-            content: `Based on this context, what is this developer likely working on?\n\n${parts.join("\n")}`,
-          },
-        ],
-        max_tokens: 100,
-        temperature: 0.3,
-      }),
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (!res.ok) {
-      return null;
-    }
-
-    const data = (await res.json()) as {
-      choices: Array<{ message: { content: string } }>;
-    };
-    return data.choices[0]?.message?.content?.trim() ?? null;
-  } catch {
-    return null;
-  }
+  return parts.join(". ") + ".";
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replaced gpt-5.4-nano summarization with local git-based summary (branch + recent files) — no API key needed
- Added fire-and-forget `openclaw system event` calls on peer registration and summary updates
- Trimmed CLAUDE.md to project-relevant content only
- Registered as user-scoped MCP server in `~/.claude.json`

## Test plan
- [ ] Open two Claude Code terminals, verify `list_peers` shows both instances
- [ ] Send a message between peers via `send_message`
- [ ] Verify OpenClaw receives registration events (check Discord logs channel)
- [ ] Verify auto-summary generates from git context without OpenAI key

🤖 Generated with [Claude Code](https://claude.com/claude-code)