### PR TITLE
fix: use process.execPath for broker spawn

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -71,7 +71,7 @@ async function ensureBroker(): Promise<void> {
   }
 
   log("Starting broker daemon...");
-  const proc = Bun.spawn(["bun", BROKER_SCRIPT], {
+  const proc = Bun.spawn([process.execPath, BROKER_SCRIPT], {
     stdio: ["ignore", "ignore", "inherit"],
     // Detach so the broker survives if this MCP server exits
     // On macOS/Linux, the broker will keep running


### PR DESCRIPTION
Hardcoded `"bun"` in `Bun.spawn()` fails when the MCP server runs in a non-interactive shell context where `PATH` doesn't include `~/.bun/bin/`.

`process.execPath` resolves to the absolute path of the currently running Bun interpreter, making the broker spawn reliable regardless of PATH configuration.

**Before:** `Bun.spawn(["bun", BROKER_SCRIPT], ...)`
**After:** `Bun.spawn([process.execPath, BROKER_SCRIPT], ...)`

One-line change, no breaking changes. Tested on Linux (ZSH, non-interactive MCP context).