### PR TITLE
Fix silent message loss when channel push is not active

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,31 @@ claude mcp add --scope user --transport stdio claude-peers -- bun ~/claude-peers
 
 Replace `~/claude-peers-mcp` with wherever you cloned it.
 
-### 3. Run Claude Code with the channel
+### 3. Start Claude Code
+
+The tools work in any Claude Code session. Just start normally:
 
 ```bash
-claude --dangerously-skip-permissions --dangerously-load-development-channels server:claude-peers
+claude
 ```
 
-That's it. The broker daemon starts automatically the first time.
+Messages are delivered **automatically** whenever Claude calls any claude-peers tool (`list_peers`, `send_message`, `set_summary`) — they piggyback on the tool response. This works with any auth method, including Bedrock and API keys.
 
-> **Tip:** Add it to an alias so you don't have to type it every time:
+For **instant push delivery** (messages arrive mid-task without waiting for a tool call), start with the channel flag instead:
+
+```bash
+claude --dangerously-load-development-channels server:claude-peers
+```
+
+> **Note:** Channel push requires claude.ai login — Bedrock and API key auth fall back to piggyback delivery automatically.
+
+> **Tip:** Add an alias so you don't have to type it every time:
 >
 > ```bash
 > alias claudepeers='claude --dangerously-load-development-channels server:claude-peers'
 > ```
+
+The broker daemon starts automatically the first time.
 
 ### 4. Open a second session and try it
 
@@ -64,13 +76,18 @@ The other Claude receives it immediately and responds.
 | Tool             | What it does                                                                   |
 | ---------------- | ------------------------------------------------------------------------------ |
 | `list_peers`     | Find other Claude Code instances — scoped to `machine`, `directory`, or `repo` |
-| `send_message`   | Send a message to another instance by ID (arrives instantly via channel push)  |
+| `send_message`   | Send a message to another instance by ID                                       |
 | `set_summary`    | Describe what you're working on (visible to other peers)                       |
-| `check_messages` | Manually check for messages (fallback if not using channel mode)               |
+| `check_messages` | Manually check for messages                                                    |
 
 ## How it works
 
-A **broker daemon** runs on `localhost:7899` with a SQLite database. Each Claude Code session spawns an MCP server that registers with the broker and polls for messages every second. Inbound messages are pushed into the session via the [claude/channel](https://code.claude.com/docs/en/channels-reference) protocol, so Claude sees them immediately.
+A **broker daemon** runs on `localhost:7899` with a SQLite database. Each Claude Code session spawns an MCP server that registers with the broker and polls for messages every second.
+
+Messages are delivered through two paths:
+
+- **Channel push** (with `--dangerously-load-development-channels`): inbound messages are pushed into the session via the [claude/channel](https://code.claude.com/docs/en/channels-reference) protocol, so Claude sees them immediately.
+- **Piggyback delivery** (default): pending messages are appended to any claude-peers tool response. When Claude calls `list_peers`, `send_message`, or `set_summary`, it gets the tool result plus any waiting messages. No channels required — works with any auth method.
 
 ```
                     ┌───────────────────────────┐
@@ -117,4 +134,4 @@ bun cli.ts kill-broker       # stop the broker
 
 - [Bun](https://bun.sh)
 - Claude Code v2.1.80+
-- claude.ai login (channels require it — API key auth won't work)
+- Any auth method (Bedrock, API key, claude.ai). Channel push requires claude.ai login; piggyback delivery works with all.

--- a/broker.ts
+++ b/broker.ts
@@ -208,6 +208,11 @@ function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: str
   return { ok: true };
 }
 
+function handlePeekMessages(body: PollMessagesRequest): PollMessagesResponse {
+  const messages = selectUndelivered.all(body.id) as Message[];
+  return { messages };
+}
+
 function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
   const messages = selectUndelivered.all(body.id) as Message[];
 
@@ -255,6 +260,8 @@ Bun.serve({
           return Response.json(handleListPeers(body as ListPeersRequest));
         case "/send-message":
           return Response.json(handleSendMessage(body as SendMessageRequest));
+        case "/peek-messages":
+          return Response.json(handlePeekMessages(body as PollMessagesRequest));
         case "/poll-messages":
           return Response.json(handlePollMessages(body as PollMessagesRequest));
         case "/unregister":

--- a/server.ts
+++ b/server.ts
@@ -139,6 +139,10 @@ let myId: PeerId | null = null;
 let myCwd = process.cwd();
 let myGitRoot: string | null = null;
 
+// Track message IDs already pushed via channel notification to avoid duplicates.
+// Messages are only truly consumed when Claude calls check_messages (which uses /poll-messages).
+const pushedMessageIds = new Set<number>();
+
 // --- MCP Server ---
 
 const mcp = new Server(
@@ -160,7 +164,9 @@ Available tools:
 - set_summary: Set a 1-2 sentence summary of what you're working on (visible to other peers)
 - check_messages: Manually check for new messages
 
-When you start, proactively call set_summary to describe what you're working on. This helps other instances understand your context.`,
+When you start, proactively call set_summary to describe what you're working on. This helps other instances understand your context.
+
+IMPORTANT: Channel push notifications only work when Claude Code is started with --dangerously-load-development-channels server:claude-peers (or --channels). If you are NOT receiving <channel> messages, call check_messages periodically to poll for new messages manually. This is the reliable fallback that always works regardless of how Claude Code was started.`,
   }
 );
 
@@ -364,7 +370,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         };
       }
       try {
+        // /poll-messages marks messages as delivered — this is the authoritative delivery path.
+        // Channel notifications (from the poll loop) are best-effort and may be silently
+        // ignored if channels aren't enabled.
         const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+
+        // Clear consumed IDs from the pushed set so they won't be re-pushed
+        for (const msg of result.messages) {
+          pushedMessageIds.delete(msg.id);
+        }
+
         if (result.messages.length === 0) {
           return {
             content: [{ type: "text" as const, text: "No new messages." }],
@@ -405,9 +420,16 @@ async function pollAndPushMessages() {
   if (!myId) return;
 
   try {
-    const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+    // Use /peek-messages to read without consuming. Messages stay undelivered in the
+    // broker until Claude explicitly calls check_messages (which uses /poll-messages).
+    // This prevents the silent message loss that occurred when channel notifications
+    // were ignored by Claude Code (e.g., channels not enabled, Bedrock auth).
+    const result = await brokerFetch<PollMessagesResponse>("/peek-messages", { id: myId });
 
     for (const msg of result.messages) {
+      // Skip messages we already pushed — avoids duplicate channel notifications
+      if (pushedMessageIds.has(msg.id)) continue;
+
       // Look up the sender's info for context
       let fromSummary = "";
       let fromCwd = "";
@@ -426,7 +448,8 @@ async function pollAndPushMessages() {
         // Non-critical, proceed without sender info
       }
 
-      // Push as channel notification — this is what makes it immediate
+      // Push as channel notification — this is what makes it immediate when channels
+      // are enabled via --dangerously-load-development-channels or --channels.
       await mcp.notification({
         method: "notifications/claude/channel",
         params: {
@@ -440,6 +463,7 @@ async function pollAndPushMessages() {
         },
       });
 
+      pushedMessageIds.add(msg.id);
       log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
     }
   } catch (e) {

--- a/server.ts
+++ b/server.ts
@@ -235,6 +235,39 @@ const TOOLS = [
   },
 ];
 
+// --- Piggyback delivery ---
+// Drain pending messages and return them as extra content items to append to any tool response.
+// This is the reliable delivery path when channels aren't available (e.g., Bedrock auth):
+// messages arrive automatically whenever Claude interacts with any claude-peers tool.
+
+async function drainPendingMessages(): Promise<Array<{ type: "text"; text: string }>> {
+  if (!myId) return [];
+
+  try {
+    const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+
+    for (const msg of result.messages) {
+      pushedMessageIds.delete(msg.id);
+    }
+
+    if (result.messages.length === 0) return [];
+
+    const lines = result.messages.map((m) => {
+      const parts = [`From ${m.from_id} (${m.sent_at}):\n${m.text}`];
+      return parts.join("");
+    });
+
+    return [
+      {
+        type: "text" as const,
+        text: `\n📨 ${result.messages.length} pending peer message(s):\n\n${lines.join("\n\n---\n\n")}\n\nIMPORTANT: Respond to these messages using send_message before continuing your current work.`,
+      },
+    ];
+  } catch {
+    return [];
+  }
+}
+
 // --- Tool handlers ---
 
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -262,6 +295,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
                 type: "text" as const,
                 text: `No other Claude Code instances found (scope: ${scope}).`,
               },
+              ...await drainPendingMessages(),
             ],
           };
         }
@@ -285,6 +319,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
               type: "text" as const,
               text: `Found ${peers.length} peer(s) (scope: ${scope}):\n\n${lines.join("\n\n")}`,
             },
+            ...await drainPendingMessages(),
           ],
         };
       } catch (e) {
@@ -321,7 +356,10 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           };
         }
         return {
-          content: [{ type: "text" as const, text: `Message sent to peer ${to_id}` }],
+          content: [
+            { type: "text" as const, text: `Message sent to peer ${to_id}` },
+            ...await drainPendingMessages(),
+          ],
         };
       } catch (e) {
         return {
@@ -347,7 +385,10 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       try {
         await brokerFetch("/set-summary", { id: myId, summary });
         return {
-          content: [{ type: "text" as const, text: `Summary updated: "${summary}"` }],
+          content: [
+            { type: "text" as const, text: `Summary updated: "${summary}"` },
+            ...await drainPendingMessages(),
+          ],
         };
       } catch (e) {
         return {
@@ -370,12 +411,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         };
       }
       try {
-        // /poll-messages marks messages as delivered — this is the authoritative delivery path.
-        // Channel notifications (from the poll loop) are best-effort and may be silently
-        // ignored if channels aren't enabled.
         const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
 
-        // Clear consumed IDs from the pushed set so they won't be re-pushed
         for (const msg of result.messages) {
           pushedMessageIds.delete(msg.id);
         }


### PR DESCRIPTION
## Problem

Two issues with message delivery:

### 1. Silent message loss when channels aren't active
The polling loop calls `/poll-messages` every second, which **marks messages as delivered in the broker**. It then pushes them via `mcp.notification()`. When channel push is not active — because Claude Code was started without `--dangerously-load-development-channels` / `--channels`, or because the session uses Bedrock/API key auth (which [doesn't support channels](https://code.claude.com/docs/en/channels-reference)) — Claude Code **silently ignores** the notification. Messages vanish.

### 2. No delivery path without channels
The only fallback was `check_messages`, which requires Claude to remember to call it. Claude forgets, so messages sit in the broker indefinitely.

## Fix

### Commit 1: Peek/consume split (prevents message loss)
- **broker.ts**: Add `/peek-messages` endpoint — returns undelivered messages without marking them delivered
- **server.ts**: Poll loop uses `/peek-messages` (non-destructive) + tracks pushed IDs to avoid duplicate notifications
- `check_messages` still uses `/poll-messages` (authoritative delivery)

### Commit 2: Piggyback delivery (works without channels)
- Every tool response (`list_peers`, `send_message`, `set_summary`) now drains pending messages and appends them to the result
- Claude doesn't need to remember anything — messages arrive naturally whenever it interacts with any claude-peers tool
- Works on Bedrock, API key auth, and any environment where channels aren't available

### Message flow after fix

| Scenario | How messages arrive |
|---|---|
| Channels enabled (claude.ai auth + `--channels`) | Immediate push via `notifications/claude/channel` |
| Channels **not** available (Bedrock, no flag) | Piggybacked on next claude-peers tool call |
| `check_messages` called explicitly | Still works as before |

## Tests

```
=== OLD BEHAVIOR (poll-messages in loop) ===
  Poll cycle 1: consumed 1 message(s)
  check_messages returns: 0 message(s)
  RESULT: MESSAGE LOST (bug)

=== NEW BEHAVIOR (peek-messages in loop) ===
  Poll cycle 1: peeked 1, pushed 1 new notification(s)
  Poll cycle 2: peeked 1, pushed 0 new (deduped)
  check_messages returns: 1 message(s) — "hello-new"
  RESULT: MESSAGE PRESERVED (fix works)

=== PIGGYBACK DELIVERY TEST ===
  Sender sent a message to peer
  Poll loop peeked: 1 message(s), pushed notification (ignored)
  Peer calls set_summary...
    Tool response: Summary updated
    PIGGYBACKED: message delivered alongside tool result
  RESULT: PASS — message delivered via piggyback
```