### PR TITLE
fix stale peer cleanup and module entry point

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -58,15 +58,25 @@ db.run(`
   )
 `);
 
-// Clean up stale peers (PIDs that no longer exist) on startup
+// Peers that haven't sent a heartbeat within this window are considered stale,
+// even if their PID is still alive (PID reuse by unrelated processes).
+const STALE_TIMEOUT_MS = 60_000;
+
+// Clean up stale peers (dead PIDs or missed heartbeats) on startup
 function cleanStalePeers() {
-  const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
+  const now = Date.now();
+  const peers = db.query("SELECT id, pid, last_seen FROM peers").all() as { id: string; pid: number; last_seen: string }[];
   for (const peer of peers) {
+    const lastSeen = new Date(peer.last_seen).getTime();
+    const isHeartbeatStale = now - lastSeen > STALE_TIMEOUT_MS;
+    let isPidDead = false;
     try {
-      // Check if process is still alive (signal 0 doesn't kill, just checks)
       process.kill(peer.pid, 0);
     } catch {
-      // Process doesn't exist, remove it
+      isPidDead = true;
+    }
+
+    if (isPidDead || isHeartbeatStale) {
       db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
       db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
     }
@@ -184,16 +194,23 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
     peers = peers.filter((p) => p.id !== body.exclude_id);
   }
 
-  // Verify each peer's process is still alive
+  // Verify each peer is still alive (PID exists AND heartbeat is recent)
+  const now = Date.now();
   return peers.filter((p) => {
+    const lastSeen = new Date(p.last_seen).getTime();
+    const isHeartbeatStale = now - lastSeen > STALE_TIMEOUT_MS;
+    let isPidDead = false;
     try {
       process.kill(p.pid, 0);
-      return true;
     } catch {
-      // Clean up dead peer
+      isPidDead = true;
+    }
+
+    if (isPidDead || isHeartbeatStale) {
       deletePeer.run(p.id);
       return false;
     }
+    return true;
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-peers",
   "version": "0.1.0",
   "description": "Peer discovery and messaging for Claude Code instances",
-  "module": "index.ts",
+  "module": "server.ts",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Problem
When a Claude Code session exits, its PID can be reused by an unrelated process (e.g., `sleep`). The broker's `cleanStalePeers()` only checks `process.kill(pid, 0)` - so the ghost peer stays alive in the registry. Other peers discover it via `list_peers`, send messages to it, and those messages are never delivered.

## Fix
Peers that miss heartbeats for 60s are now removed regardless of PID state. The heartbeat interval is 15s, so this allows 4 missed beats before eviction. Applied to both `cleanStalePeers()` and `handleListPeers()`.

Also fixed `package.json` `module` field pointing to `index.ts` (empty `export {}`) instead of `server.ts` ... the actual MCP server entry point.

## Summary
- Fix stale peer cleanup: add 60s heartbeat timeout in addition to PID check
- Fix `module` entry point in package.json (`index.ts` → `server.ts`)