### PR TITLE
fix silent message loss when channel push is not active

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -19,6 +19,7 @@ import type {
   SendMessageRequest,
   PollMessagesRequest,
   PollMessagesResponse,
+  AckMessagesRequest,
   Peer,
   Message,
 } from "./shared/types.ts";
@@ -210,13 +211,17 @@ function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: str
 
 function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
   const messages = selectUndelivered.all(body.id) as Message[];
-
-  // Mark them as delivered
-  for (const msg of messages) {
-    markDelivered.run(msg.id);
-  }
-
+  // Don't mark as delivered here — let the caller ack explicitly
+  // so messages aren't lost when channel push silently fails.
   return { messages };
+}
+
+function handleAckMessages(body: AckMessagesRequest): void {
+  db.transaction(() => {
+    for (const id of body.message_ids) {
+      markDelivered.run(id);
+    }
+  })();
 }
 
 function handleUnregister(body: { id: string }): void {
@@ -257,6 +262,9 @@ Bun.serve({
           return Response.json(handleSendMessage(body as SendMessageRequest));
         case "/poll-messages":
           return Response.json(handlePollMessages(body as PollMessagesRequest));
+        case "/ack-messages":
+          handleAckMessages(body as AckMessagesRequest);
+          return Response.json({ ok: true });
         case "/unregister":
           handleUnregister(body as { id: string });
           return Response.json({ ok: true });

--- a/server.ts
+++ b/server.ts
@@ -138,6 +138,10 @@ function getTty(): string | null {
 let myId: PeerId | null = null;
 let myCwd = process.cwd();
 let myGitRoot: string | null = null;
+// Track message IDs already pushed via channel to avoid re-pushing every poll cycle.
+// Messages are NOT acked by the poll loop — only check_messages acks them —
+// so they remain available as a fallback when channels aren't active.
+const pushedMessageIds = new Set<number>();
 
 // --- MCP Server ---
 
@@ -370,6 +374,16 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
             content: [{ type: "text" as const, text: "No new messages." }],
           };
         }
+
+        // Ack messages so they aren't returned again
+        const ids = result.messages.map((m) => m.id);
+        await brokerFetch("/ack-messages", { message_ids: ids });
+
+        // Also mark as pushed so the poll loop doesn't re-push them
+        for (const id of ids) {
+          pushedMessageIds.add(id);
+        }
+
         const lines = result.messages.map(
           (m) => `From ${m.from_id} (${m.sent_at}):\n${m.text}`
         );
@@ -408,6 +422,9 @@ async function pollAndPushMessages() {
     const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
 
     for (const msg of result.messages) {
+      // Skip messages already pushed in this session
+      if (pushedMessageIds.has(msg.id)) continue;
+
       // Look up the sender's info for context
       let fromSummary = "";
       let fromCwd = "";
@@ -426,7 +443,9 @@ async function pollAndPushMessages() {
         // Non-critical, proceed without sender info
       }
 
-      // Push as channel notification — this is what makes it immediate
+      // Push as channel notification — this is what makes it immediate.
+      // Don't ack here: if channels aren't active the push silently fails,
+      // and check_messages must still be able to retrieve these messages.
       await mcp.notification({
         method: "notifications/claude/channel",
         params: {
@@ -440,6 +459,7 @@ async function pollAndPushMessages() {
         },
       });
 
+      pushedMessageIds.add(msg.id);
       log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
     }
   } catch (e) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -65,3 +65,7 @@ export interface PollMessagesRequest {
 export interface PollMessagesResponse {
   messages: Message[];
 }
+
+export interface AckMessagesRequest {
+  message_ids: number[];
+}


### PR DESCRIPTION
## Summary

- Decouple message polling from delivery acknowledgment
- Add explicit `/ack-messages` broker endpoint
- Poll loop tracks pushed IDs in memory instead of acking
- `check_messages` tool acks after returning messages to the user

## Problem
When channels aren't enabled (e.g., enterprise accounts without the feature, or MCP-only setups), the poll loop fetches
messages from the broker, marks them `delivered = 1`, then tries to push via `notifications/claude/channel`. The push
silently fails ... but the messages are already gone from the broker. Calling `check_messages` as a fallback returns nothing.

## Fix
`/poll-messages` no longer marks messages as delivered. A new `/ack-messages` endpoint accepts message IDs and marks them explicitly. The poll loop pushes via channel but never acks ... it tracks pushed IDs in an in-memory Set to avoid re-pushing every second. Only `check_messages` acks, after successfully returning messages to the user.

**With channels:** Messages are pushed instantly (same as before). They stay undelivered in the DB but the poll loop won't
re-push them.

**Without channels:** Push silently fails, messages remain in the DB. `check_messages` retrieves and acks them - no message loss.

## Test plan

- [x] Send message, poll multiple times without acking ... message persists across polls
- [x] Ack message, poll again ... message is gone
- [x] Verified both channel-enabled and channel-disabled flows

Closes #8