### PR TITLE
fix: Windows compatibility for peer discovery

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -24,7 +24,7 @@ import type {
 } from "./shared/types.ts";
 
 const PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
-const DB_PATH = process.env.CLAUDE_PEERS_DB ?? `${process.env.HOME}/.claude-peers.db`;
+const DB_PATH = process.env.CLAUDE_PEERS_DB ?? `${process.env.HOME ?? process.env.USERPROFILE}/.claude-peers.db`;
 
 // --- Database setup ---
 
@@ -58,15 +58,39 @@ db.run(`
   )
 `);
 
+// Check if a process is alive (cross-platform)
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    // On Unix, ESRCH means "no such process" — it's dead.
+    // EPERM means "exists but we can't signal it" — it's alive.
+    if (e?.code === "EPERM") return true;
+    // On Windows, process.kill(pid, 0) is unreliable.
+    // Fall back to tasklist to check if the PID exists.
+    if (process.platform === "win32") {
+      try {
+        const result = Bun.spawnSync(["tasklist", "/FI", `PID eq ${pid}`, "/NH"], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const output = new TextDecoder().decode(result.stdout);
+        return output.includes(String(pid));
+      } catch {
+        // If tasklist fails, assume alive to avoid false cleanup
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
 // Clean up stale peers (PIDs that no longer exist) on startup
 function cleanStalePeers() {
   const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
   for (const peer of peers) {
-    try {
-      // Check if process is still alive (signal 0 doesn't kill, just checks)
-      process.kill(peer.pid, 0);
-    } catch {
-      // Process doesn't exist, remove it
+    if (!isProcessAlive(peer.pid)) {
       db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
       db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
     }
@@ -186,14 +210,12 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
 
   // Verify each peer's process is still alive
   return peers.filter((p) => {
-    try {
-      process.kill(p.pid, 0);
+    if (isProcessAlive(p.pid)) {
       return true;
-    } catch {
-      // Clean up dead peer
-      deletePeer.run(p.id);
-      return false;
     }
+    // Clean up dead peer
+    deletePeer.run(p.id);
+    return false;
   });
 }
 
@@ -208,10 +230,16 @@ function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: str
   return { ok: true };
 }
 
+function handlePeekMessages(body: PollMessagesRequest): PollMessagesResponse {
+  // Read without marking as delivered — used by the auto-polling loop
+  const messages = selectUndelivered.all(body.id) as Message[];
+  return { messages };
+}
+
 function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
   const messages = selectUndelivered.all(body.id) as Message[];
 
-  // Mark them as delivered
+  // Mark them as delivered — only called by explicit check_messages
   for (const msg of messages) {
     markDelivered.run(msg.id);
   }
@@ -255,6 +283,8 @@ Bun.serve({
           return Response.json(handleListPeers(body as ListPeersRequest));
         case "/send-message":
           return Response.json(handleSendMessage(body as SendMessageRequest));
+        case "/peek-messages":
+          return Response.json(handlePeekMessages(body as PollMessagesRequest));
         case "/poll-messages":
           return Response.json(handlePollMessages(body as PollMessagesRequest));
         case "/unregister":

--- a/server.ts
+++ b/server.ts
@@ -38,7 +38,11 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const BROKER_SCRIPT = (() => {
+  const raw = new URL("./broker.ts", import.meta.url).pathname;
+  // On Windows, pathname may be "/C:/..." — strip the leading slash
+  return raw.match(/^\/[A-Za-z]:/) ? raw.slice(1) : raw;
+})();
 
 // --- Broker communication ---
 
@@ -364,7 +368,14 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         };
       }
       try {
+        // poll-messages marks as delivered — this is the explicit consume path
         const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+
+        // Clean up dedup set for consumed messages
+        for (const m of result.messages) {
+          notifiedMessageIds.delete(m.id);
+        }
+
         if (result.messages.length === 0) {
           return {
             content: [{ type: "text" as const, text: "No new messages." }],
@@ -401,13 +412,21 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 
 // --- Polling loop for inbound messages ---
 
+// Track which messages we've already pushed as notifications (dedup)
+const notifiedMessageIds = new Set<number>();
+
 async function pollAndPushMessages() {
   if (!myId) return;
 
   try {
-    const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+    // Use /peek-messages — reads without marking as delivered
+    // Messages stay available for check_messages to consume explicitly
+    const result = await brokerFetch<PollMessagesResponse>("/peek-messages", { id: myId });
 
     for (const msg of result.messages) {
+      // Skip if we already pushed this notification
+      if (notifiedMessageIds.has(msg.id)) continue;
+      notifiedMessageIds.add(msg.id);
       // Look up the sender's info for context
       let fromSummary = "";
       let fromCwd = "";


### PR DESCRIPTION
## Summary

- **Bug**: `process.kill(pid, 0)` throws on Windows even for alive processes, causing the broker to treat all peers as dead. `cleanStalePeers()` and `handleListPeers()` silently remove every peer, so `list_peers` always returns empty.
- **Fix**: Added `isProcessAlive()` helper that catches `EPERM` (alive but unprivileged) and falls back to `tasklist /FI "PID eq X"` on Windows.
- Also fixes `BROKER_SCRIPT` path resolution on Windows (`/C:/...` → `C:/...`) and improves message polling with peek/dedup to avoid consuming messages during auto-poll.

## Test plan

- [x] Tested on Windows 11 with two concurrent Claude Code sessions
- [x] Both sessions discover each other via `list_peers` (scope: machine)
- [x] Bidirectional messaging works (`send_message` + channel notifications)
- [x] Stale peer cleanup still works (killed a session, it disappeared from list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)