### PR TITLE
Fix at-most-once message delivery with hardened ack protocol

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -19,6 +19,7 @@ import type {
   SendMessageRequest,
   PollMessagesRequest,
   PollMessagesResponse,
+  AckMessagesRequest,
   Peer,
   Message,
 } from "./shared/types.ts";
@@ -119,7 +120,7 @@ const selectUndelivered = db.prepare(`
 `);
 
 const markDelivered = db.prepare(`
-  UPDATE messages SET delivered = 1 WHERE id = ?
+  UPDATE messages SET delivered = 1 WHERE id = ? AND to_id = ?
 `);
 
 // --- Generate peer ID ---
@@ -210,13 +211,13 @@ function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: str
 
 function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
   const messages = selectUndelivered.all(body.id) as Message[];
-
-  // Mark them as delivered
-  for (const msg of messages) {
-    markDelivered.run(msg.id);
-  }
-
   return { messages };
+}
+
+function handleAckMessages(body: AckMessagesRequest): void {
+  for (const id of body.ids) {
+    markDelivered.run(id, body.peer_id);
+  }
 }
 
 function handleUnregister(body: { id: string }): void {
@@ -257,6 +258,9 @@ Bun.serve({
           return Response.json(handleSendMessage(body as SendMessageRequest));
         case "/poll-messages":
           return Response.json(handlePollMessages(body as PollMessagesRequest));
+        case "/ack-messages":
+          handleAckMessages(body as AckMessagesRequest);
+          return Response.json({ ok: true });
         case "/unregister":
           handleUnregister(body as { id: string });
           return Response.json({ ok: true });

--- a/server.ts
+++ b/server.ts
@@ -370,6 +370,14 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
             content: [{ type: "text" as const, text: "No new messages." }],
           };
         }
+
+        const ids = result.messages.map((m) => m.id);
+        try {
+          await brokerFetch("/ack-messages", { peer_id: myId, ids });
+        } catch (e) {
+          log(`Failed to ack messages: ${e instanceof Error ? e.message : String(e)}`);
+        }
+
         const lines = result.messages.map(
           (m) => `From ${m.from_id} (${m.sent_at}):\n${m.text}`
         );
@@ -406,9 +414,9 @@ async function pollAndPushMessages() {
 
   try {
     const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+    const ackedIds: number[] = [];
 
     for (const msg of result.messages) {
-      // Look up the sender's info for context
       let fromSummary = "";
       let fromCwd = "";
       try {
@@ -426,24 +434,35 @@ async function pollAndPushMessages() {
         // Non-critical, proceed without sender info
       }
 
-      // Push as channel notification — this is what makes it immediate
-      await mcp.notification({
-        method: "notifications/claude/channel",
-        params: {
-          content: msg.text,
-          meta: {
-            from_id: msg.from_id,
-            from_summary: fromSummary,
-            from_cwd: fromCwd,
-            sent_at: msg.sent_at,
+      try {
+        await mcp.notification({
+          method: "notifications/claude/channel",
+          params: {
+            content: msg.text,
+            meta: {
+              message_id: msg.id,
+              from_id: msg.from_id,
+              from_summary: fromSummary,
+              from_cwd: fromCwd,
+              sent_at: msg.sent_at,
+            },
           },
-        },
-      });
+        });
+        ackedIds.push(msg.id);
+        log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+      } catch (e) {
+        log(`Failed to push message ${msg.id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
 
-      log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+    if (ackedIds.length > 0) {
+      try {
+        await brokerFetch("/ack-messages", { peer_id: myId, ids: ackedIds });
+      } catch (e) {
+        log(`Failed to ack messages: ${e instanceof Error ? e.message : String(e)}`);
+      }
     }
   } catch (e) {
-    // Broker might be down temporarily, don't crash
     log(`Poll error: ${e instanceof Error ? e.message : String(e)}`);
   }
 }
@@ -516,8 +535,13 @@ async function main() {
   await mcp.connect(new StdioServerTransport());
   log("MCP connected");
 
-  // 6. Start polling for inbound messages
-  const pollTimer = setInterval(pollAndPushMessages, POLL_INTERVAL_MS);
+  // 6. Start polling for inbound messages (serialized to prevent overlapping polls)
+  let pollTimer: Timer;
+  async function pollLoop() {
+    await pollAndPushMessages();
+    pollTimer = setTimeout(pollLoop, POLL_INTERVAL_MS);
+  }
+  pollTimer = setTimeout(pollLoop, POLL_INTERVAL_MS);
 
   // 7. Start heartbeat
   const heartbeatTimer = setInterval(async () => {
@@ -532,7 +556,7 @@ async function main() {
 
   // 8. Clean up on exit
   const cleanup = async () => {
-    clearInterval(pollTimer);
+    clearTimeout(pollTimer);
     clearInterval(heartbeatTimer);
     if (myId) {
       try {

--- a/server.ts
+++ b/server.ts
@@ -536,9 +536,19 @@ async function main() {
   log("MCP connected");
 
   // 6. Start polling for inbound messages (serialized to prevent overlapping polls)
+  const POLL_TIMEOUT_MS = 10_000;
   let pollTimer: Timer;
   async function pollLoop() {
-    await pollAndPushMessages();
+    try {
+      await Promise.race([
+        pollAndPushMessages(),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("poll timed out")), POLL_TIMEOUT_MS)
+        ),
+      ]);
+    } catch (e) {
+      log(`Poll error: ${e}`);
+    }
     pollTimer = setTimeout(pollLoop, POLL_INTERVAL_MS);
   }
   pollTimer = setTimeout(pollLoop, POLL_INTERVAL_MS);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -65,3 +65,8 @@ export interface PollMessagesRequest {
 export interface PollMessagesResponse {
   messages: Message[];
 }
+
+export interface AckMessagesRequest {
+  peer_id: PeerId;
+  ids: number[];
+}


### PR DESCRIPTION
The broker previously marked messages as delivered in handlePollMessages before the MCP server had actually pushed them via mcp.notification(). If the server crashed or the notification failed, messages were permanently lost.

Changes:
- Add /ack-messages endpoint: poll returns messages without marking them delivered; server explicitly acks after successful push
- Serialize poll loop with recursive setTimeout to prevent overlapping polls from delivering duplicate messages
- Scope /ack-messages to require peer_id and verify message ownership to prevent cross-peer ack abuse
- Include message_id in channel notification meta for client-side dedup

Assisted-by: claude-opus-4-6
Tested: manually