### PR TITLE
fix: resolve broker.ts path on Windows

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -38,7 +38,7 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
 
 // --- Broker communication ---
 


### PR DESCRIPTION
## Problem

On Windows, `new URL("./broker.ts", import.meta.url).pathname` returns a path with a leading slash before the drive letter:

```
/C:/Users/anzal/claude-peers-mcp/broker.ts
```

Bun cannot resolve this path, causing the broker daemon to fail immediately on startup:

```
[claude-peers] Starting broker daemon...
error: Module not found "/C:/Users/anzal/claude-peers-mcp/broker.ts"
[claude-peers] Fatal: Failed to start broker daemon after 6 seconds
```

This means `claude mcp list` always shows `claude-peers: ✗ Failed to connect` on Windows, making the MCP completely unusable.

## Fix

Strip the leading slash before a Windows drive letter using a simple regex replace:

```ts
// Before
const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;

// After
const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
```

The regex only matches paths starting with `/X:` (Windows drive letters), so it is a no-op on macOS and Linux.

## Tested on

- Windows 11 with Bun 1.3.11
- Verified `claude mcp list` shows `✓ Connected` after the fix