### PR TITLE
feat: Role system & auto-announce for persistent peer identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `CLAUDE_PEERS_ROLE` environment variable for assigning roles to Claude Code instances
+- Role field in broker's peers table and all peer-related API responses
+- Auto-announce: workers with a role automatically notify coordinators on startup
+- Role display in CLI `status` and `peers` commands
+- SQLite migration for existing databases (adds `role` column)
 - Role field to `Peer` interface in `shared/types.ts` to support peer role identification
 - Role field to `RegisterRequest` interface in `shared/types.ts` for peer registration with role information
 - Test suite for type definitions in `tests/types.test.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Auto-announce: workers with a role automatically notify coordinators on startup
 - Role display in CLI `status` and `peers` commands
 - SQLite migration for existing databases (adds `role` column)
+- `spawn_peers` MCP tool: spawn Claude Code instances in Ghostty terminal splits with assigned roles (macOS, Ghostty 1.3+)
+- `shared/spawner.ts`: Ghostty AppleScript generation and execution module
 - Role field to `Peer` interface in `shared/types.ts` to support peer role identification
 - Role field to `RegisterRequest` interface in `shared/types.ts` for peer registration with role information
 - Test suite for type definitions in `tests/types.test.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Role field to `Peer` interface in `shared/types.ts` to support peer role identification
+- Role field to `RegisterRequest` interface in `shared/types.ts` for peer registration with role information
+- Test suite for type definitions in `tests/types.test.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,141 +1,86 @@
----
-description: Use Bun instead of Node.js, npm, pnpm, or vite.
-globs: "*.ts, *.tsx, *.html, *.css, *.js, *.jsx, package.json"
-alwaysApply: false
----
+# CLAUDE.md
 
-# claude-peers
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Peer discovery and messaging MCP channel for Claude Code instances.
+## Project Overview
+
+claude-peers is an MCP (Model Context Protocol) server that enables peer discovery and real-time messaging between Claude Code instances on the same machine. It uses a broker-client architecture where a shared daemon manages peer registration and message routing.
+
+## Commands
+
+```bash
+# Install dependencies
+bun install
+
+# Run the MCP server (normally spawned by Claude Code, not run directly)
+bun server.ts
+
+# Run the broker daemon directly (auto-launched by server.ts if not running)
+bun broker.ts
+
+# CLI commands
+bun cli.ts status            # Broker status + all peers
+bun cli.ts peers             # List peers
+bun cli.ts send <id> <msg>   # Send a message to a peer
+bun cli.ts kill-broker       # Stop the broker daemon
+
+# Start Claude Code with channel support
+claude --dangerously-load-development-channels server:claude-peers
+
+# Run tests
+bun test
+```
 
 ## Architecture
 
-- `broker.ts` — Singleton HTTP daemon on localhost:7899 + SQLite. Auto-launched by the MCP server.
-- `server.ts` — MCP stdio server, one per Claude Code instance. Connects to broker, exposes tools, pushes channel notifications.
-- `shared/types.ts` — Shared TypeScript types for broker API.
-- `shared/summarize.ts` — Auto-summary generation via gpt-5.4-nano.
-- `cli.ts` — CLI utility for inspecting broker state.
+### Broker-Client Model
 
-## Running
-
-```bash
-# Start Claude Code with the channel:
-claude --dangerously-load-development-channels server:claude-peers
-
-# Or just add to .mcp.json and use as regular MCP (no channel push, but tools work):
-# { "claude-peers": { "command": "bun", "args": ["./server.ts"] } }
-
-# CLI:
-bun cli.ts status
-bun cli.ts peers
-bun cli.ts send <peer-id> <message>
-bun cli.ts kill-broker
+```
+  Claude A ↔ MCP Server A (stdio) ↔ Broker daemon (HTTP + SQLite) ↔ MCP Server B (stdio) ↔ Claude B
 ```
 
-## Bun
+- **broker.ts** — Singleton HTTP server on `127.0.0.1:7899`. Uses `bun:sqlite` for state (peers table + messages table). Auto-launched by the MCP server via `ensureBroker()`. Cleans stale peers by checking PID liveness every 30s.
+- **server.ts** — MCP stdio server, one per Claude Code session. Registers with the broker on startup, polls for messages every 1s, sends heartbeats every 15s. Pushes inbound messages as `notifications/claude/channel` for instant delivery. Unregisters on exit via SIGINT/SIGTERM handlers.
+- **shared/types.ts** — All TypeScript interfaces for the broker REST API (RegisterRequest, Peer, Message, etc.).
+- **shared/summarize.ts** — Optional auto-summary via OpenAI `gpt-5.4-nano` API. Requires `OPENAI_API_KEY`. Falls back gracefully.
+- **cli.ts** — Standalone CLI that talks directly to the broker HTTP API for debugging.
+- **index.ts** — Module marker, exports nothing.
 
-Default to using Bun instead of Node.js.
+### Broker REST API (all POST except /health GET)
 
-- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
-- Use `bun test` instead of `jest` or `vitest`
-- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
-- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
-- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
-- Use `bunx <package> <command>` instead of `npx <package> <command>`
-- Bun automatically loads .env, so don't use dotenv.
+| Endpoint          | Purpose                              |
+| ----------------- | ------------------------------------ |
+| `/register`       | Register a new peer, returns peer ID |
+| `/heartbeat`      | Update last_seen timestamp           |
+| `/set-summary`    | Update peer's summary text           |
+| `/list-peers`     | List peers by scope (machine/directory/repo) |
+| `/send-message`   | Queue a message for delivery         |
+| `/poll-messages`  | Fetch and mark-delivered unread messages |
+| `/unregister`     | Remove peer registration             |
+| `/health`         | GET — returns status + peer count    |
 
-## APIs
+### MCP Tools Exposed
 
-- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
-- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
-- `Bun.redis` for Redis. Don't use `ioredis`.
-- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
-- `WebSocket` is built-in. Don't use `ws`.
-- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
-- Bun.$`ls` instead of execa.
+`list_peers`, `send_message`, `set_summary`, `check_messages` — defined in server.ts TOOLS array.
 
-## Testing
+## Key Design Decisions
 
-Use `bun test` to run tests.
+- **Logging**: MCP stdio servers must use `console.error` (stderr) for logging — stdout is reserved for MCP protocol.
+- **Broker auto-launch**: `ensureBroker()` in server.ts spawns the broker as a detached process with `proc.unref()` so it survives MCP server exit.
+- **Stale peer cleanup**: Broker uses `process.kill(pid, 0)` to check if peer processes are alive.
+- **Channel push**: Messages arrive instantly via `notifications/claude/channel` MCP notification, not tool responses.
+- **Summary generation**: Non-blocking on startup — races with a 3s timeout, applies late if slow.
 
-```ts#index.test.ts
-import { test, expect } from "bun:test";
+## Runtime & Tooling
 
-test("hello world", () => {
-  expect(1).toBe(1);
-});
-```
+- **Bun only** — no Node.js, no npm/yarn/pnpm. Use `bun:sqlite` (not better-sqlite3), `Bun.serve()` (not express), `Bun.spawn()` (not execa).
+- Single dependency: `@modelcontextprotocol/sdk`.
 
-## Frontend
+## Environment Variables
 
-Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
-
-Server:
-
-```ts#index.ts
-import index from "./index.html"
-
-Bun.serve({
-  routes: {
-    "/": index,
-    "/api/users/:id": {
-      GET: (req) => {
-        return new Response(JSON.stringify({ id: req.params.id }));
-      },
-    },
-  },
-  // optional websocket support
-  websocket: {
-    open: (ws) => {
-      ws.send("Hello, world!");
-    },
-    message: (ws, message) => {
-      ws.send(message);
-    },
-    close: (ws) => {
-      // handle close
-    }
-  },
-  development: {
-    hmr: true,
-    console: true,
-  }
-})
-```
-
-HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
-
-```html#index.html
-<html>
-  <body>
-    <h1>Hello, world!</h1>
-    <script type="module" src="./frontend.tsx"></script>
-  </body>
-</html>
-```
-
-With the following `frontend.tsx`:
-
-```tsx#frontend.tsx
-import React from "react";
-import { createRoot } from "react-dom/client";
-
-// import .css files directly and it works
-import './index.css';
-
-const root = createRoot(document.body);
-
-export default function Frontend() {
-  return <h1>Hello, world!</h1>;
-}
-
-root.render(<Frontend />);
-```
-
-Then, run index.ts
-
-```sh
-bun --hot ./index.ts
-```
-
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.
+| Variable            | Default              | Description                           |
+| ------------------- | -------------------- | ------------------------------------- |
+| `CLAUDE_PEERS_PORT` | `7899`               | Broker port                           |
+| `CLAUDE_PEERS_DB`   | `~/.claude-peers.db` | SQLite database path                  |
+| `CLAUDE_PEERS_ROLE` | `""`                 | Peer role (e.g. "frontend-dev", "koordinator") |
+| `OPENAI_API_KEY`    | —                    | Enables auto-summary via gpt-5.4-nano |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ bun test
 
 ### MCP Tools Exposed
 
-`list_peers`, `send_message`, `set_summary`, `check_messages` — defined in server.ts TOOLS array.
+`list_peers`, `send_message`, `set_summary`, `check_messages`, `spawn_peers` — defined in server.ts TOOLS array.
+
+- **spawn_peers** — Opens Ghostty terminal splits and starts Claude Code instances with assigned roles. Uses AppleScript API (macOS, Ghostty 1.3+). Spawner logic in `shared/spawner.ts`.
 
 ## Key Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ If you set `OPENAI_API_KEY` in your environment, each instance generates a brief
 
 Without the API key, Claude sets its own summary via the `set_summary` tool.
 
+## Roles
+
+Assign roles to instances so coordinators recognize them automatically:
+
+```bash
+# Start with a role
+CLAUDE_PEERS_ROLE="frontend-dev" claude --dangerously-load-development-channels server:claude-peers
+
+# Handy aliases
+alias claude-koordinator='CLAUDE_PEERS_ROLE="koordinator" claude --dangerously-load-development-channels server:claude-peers'
+alias claude-frontend='CLAUDE_PEERS_ROLE="frontend-dev" claude --dangerously-load-development-channels server:claude-peers'
+alias claude-backend='CLAUDE_PEERS_ROLE="backend-dev" claude --dangerously-load-development-channels server:claude-peers'
+```
+
+When a worker with a role starts, it automatically announces itself to any coordinator in the same repo. The coordinator sees the role in `list_peers` output — no manual introduction needed.
+
 ## CLI
 
 You can also inspect and interact from the command line:
@@ -111,6 +127,7 @@ bun cli.ts kill-broker       # stop the broker
 | -------------------- | -------------------- | ------------------------------------- |
 | `CLAUDE_PEERS_PORT`  | `7899`               | Broker port                           |
 | `CLAUDE_PEERS_DB`    | `~/.claude-peers.db` | SQLite database path                  |
+| `CLAUDE_PEERS_ROLE`  | `""`                 | Peer role for auto-identification              |
 | `OPENAI_API_KEY`     | —                    | Enables auto-summary via gpt-5.4-nano |
 
 ## Requirements

--- a/broker.ts
+++ b/broker.ts
@@ -40,10 +40,17 @@ db.run(`
     git_root TEXT,
     tty TEXT,
     summary TEXT NOT NULL DEFAULT '',
+    role TEXT NOT NULL DEFAULT '',
     registered_at TEXT NOT NULL,
     last_seen TEXT NOT NULL
   )
 `);
+
+try {
+  db.run("ALTER TABLE peers ADD COLUMN role TEXT NOT NULL DEFAULT ''");
+} catch {
+  // Column already exists, ignore
+}
 
 db.run(`
   CREATE TABLE IF NOT EXISTS messages (
@@ -81,8 +88,8 @@ setInterval(cleanStalePeers, 30_000);
 // --- Prepared statements ---
 
 const insertPeer = db.prepare(`
-  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, registered_at, last_seen)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, role, registered_at, last_seen)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateLastSeen = db.prepare(`
@@ -145,7 +152,7 @@ function handleRegister(body: RegisterRequest): RegisterResponse {
     deletePeer.run(existing.id);
   }
 
-  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now);
+  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, body.role ?? "", now, now);
   return { id };
 }
 

--- a/cli.ts
+++ b/cli.ts
@@ -51,6 +51,7 @@ switch (cmd) {
             tty: string | null;
             summary: string;
             last_seen: string;
+            role: string;
           }>
         >("/list-peers", {
           scope: "machine",
@@ -60,7 +61,8 @@ switch (cmd) {
 
         console.log("\nPeers:");
         for (const p of peers) {
-          console.log(`  ${p.id}  PID:${p.pid}  ${p.cwd}`);
+          const roleTag = p.role ? ` [${p.role}]` : "";
+          console.log(`  ${p.id}  PID:${p.pid}${roleTag}  ${p.cwd}`);
           if (p.summary) console.log(`         ${p.summary}`);
           if (p.tty) console.log(`         TTY: ${p.tty}`);
           console.log(`         Last seen: ${p.last_seen}`);
@@ -83,6 +85,7 @@ switch (cmd) {
           tty: string | null;
           summary: string;
           last_seen: string;
+          role: string;
         }>
       >("/list-peers", {
         scope: "machine",
@@ -94,7 +97,8 @@ switch (cmd) {
         console.log("No peers registered.");
       } else {
         for (const p of peers) {
-          const parts = [`${p.id}  PID:${p.pid}  ${p.cwd}`];
+          const roleTag = p.role ? ` [${p.role}]` : "";
+          const parts = [`${p.id}  PID:${p.pid}${roleTag}  ${p.cwd}`];
           if (p.summary) parts.push(`  Summary: ${p.summary}`);
           console.log(parts.join("\n"));
         }

--- a/docs/superpowers/plans/2026-03-28-spawn-peers.md
+++ b/docs/superpowers/plans/2026-03-28-spawn-peers.md
@@ -1,0 +1,27 @@
+# spawn_peers Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development or superpowers:executing-plans
+
+**Goal:** Ghostty AppleScript ile Claude Code peer'larını otomatik spawn eden MCP tool'u eklemek.
+
+**Architecture:** `shared/spawner.ts` AppleScript oluşturup osascript ile çalıştırır, `server.ts` tool olarak expose eder.
+
+**Tech Stack:** TypeScript, Bun, AppleScript/osascript, Ghostty 1.3+
+
+---
+
+### Task 1: shared/spawner.ts — Ghostty Spawner
+
+**Files:**
+- Create: `shared/spawner.ts`
+- Create: `tests/spawner.test.ts`
+
+### Task 2: server.ts — spawn_peers Tool
+
+**Files:**
+- Modify: `server.ts`
+
+### Task 3: Docs ve CHANGELOG
+
+**Files:**
+- Modify: `CLAUDE.md`, `README.md`, `CHANGELOG.md`

--- a/docs/superpowers/specs/2026-03-28-spawn-peers-design.md
+++ b/docs/superpowers/specs/2026-03-28-spawn-peers-design.md
@@ -1,0 +1,120 @@
+# spawn_peers Tool Design Spec
+
+## Goal
+
+Add a `spawn_peers` MCP tool to claude-peers that opens new Ghostty terminal tabs with split panes and starts Claude Code instances with assigned roles. This eliminates the need to manually open terminals and start workers.
+
+## Requirements
+
+- New MCP tool `spawn_peers` accessible by any peer
+- Uses Ghostty's AppleScript API (macOS, Ghostty 1.3+)
+- Opens a new tab, splits it based on peer count
+- Starts Claude Code with `CLAUDE_PEERS_ROLE` env var in each pane
+- Supports 2-4 peers per spawn call
+- Optional startup prompt sent via `--prompt` flag
+- Default working directory: caller's CWD
+
+## Tool Schema
+
+```ts
+{
+  name: "spawn_peers",
+  description: "Spawn Claude Code instances in Ghostty terminal splits with assigned roles",
+  inputSchema: {
+    type: "object",
+    properties: {
+      roles: {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+        maxItems: 4,
+        description: "Roles to assign (e.g. ['frontend-dev', 'backend-dev'])"
+      },
+      prompt: {
+        type: "string",
+        description: "Optional startup prompt for each Claude instance"
+      },
+      working_directory: {
+        type: "string",
+        description: "Working directory for spawned instances. Defaults to caller's CWD."
+      }
+    },
+    required: ["roles"]
+  }
+}
+```
+
+## Architecture
+
+### File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `shared/spawner.ts` | Ghostty AppleScript generation and execution |
+| `server.ts` | `spawn_peers` tool definition and handler |
+
+### shared/spawner.ts
+
+Exports `spawnPeersInGhostty(config)` function:
+
+```ts
+interface SpawnConfig {
+  roles: string[];
+  cwd: string;
+  prompt?: string;
+}
+
+function spawnPeersInGhostty(config: SpawnConfig): Promise<{ ok: boolean; error?: string }>
+```
+
+Generates and executes AppleScript via `osascript` that:
+1. Creates a new tab in front Ghostty window with CWD
+2. Runs the first Claude command in the initial pane
+3. Splits and runs remaining Claude commands
+
+### Split Layout Strategy
+
+- **1 peer:** Single pane, no split
+- **2 peers:** Right split (side by side)
+- **3 peers:** Right split, then down split on left pane
+- **4 peers:** Right split, then down split on both panes
+
+### Claude Command Construction
+
+Each pane runs:
+```bash
+CLAUDE_PEERS_ROLE="<role>" claude --dangerously-skip-permissions --dangerously-load-development-channels server:claude-peers [--prompt "<prompt>"]
+```
+
+### AppleScript Template
+
+```applescript
+tell application "Ghostty"
+  set cfg to make new surface configuration
+  set initial working directory of cfg to "<cwd>"
+
+  -- New tab with first role
+  set t1 to new tab in front window with configuration cfg
+
+  -- Split right for second role
+  set t2 to split t1 direction right with configuration cfg
+
+  -- Send commands
+  input text "CLAUDE_PEERS_ROLE=\"frontend-dev\" claude ..." to t1
+  send key "enter" to t1
+  input text "CLAUDE_PEERS_ROLE=\"backend-dev\" claude ..." to t2
+  send key "enter" to t2
+end tell
+```
+
+## Error Handling
+
+- If Ghostty is not running: return error "Ghostty is not running"
+- If not on macOS: return error "spawn_peers requires macOS with Ghostty"
+- If osascript fails: return the stderr output
+
+## Constraints
+
+- macOS only (AppleScript)
+- Ghostty 1.3+ required (AppleScript API)
+- No fallback to other terminals (by design choice)

--- a/server.ts
+++ b/server.ts
@@ -39,6 +39,7 @@ const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const MY_ROLE = process.env.CLAUDE_PEERS_ROLE ?? "";
 
 // --- Broker communication ---
 
@@ -266,6 +267,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
             `PID: ${p.pid}`,
             `CWD: ${p.cwd}`,
           ];
+          if (p.role) parts.push(`Role: ${p.role}`);
           if (p.git_root) parts.push(`Repo: ${p.git_root}`);
           if (p.tty) parts.push(`TTY: ${p.tty}`);
           if (p.summary) parts.push(`Summary: ${p.summary}`);
@@ -448,6 +450,23 @@ async function pollAndPushMessages() {
   }
 }
 
+// --- Coordinator helpers ---
+
+const COORDINATOR_ROLES = ["koordinator", "coordinator", "coord", "koordinatör"];
+
+export function findCoordinators(peers: Peer[]): Peer[] {
+  return peers.filter((p) =>
+    COORDINATOR_ROLES.includes(p.role.toLowerCase())
+  );
+}
+
+export function buildAnnounceMessage(role: string, cwd: string): string {
+  if (role) {
+    return `[auto-announce] Peer online oldu. Rol: ${role}, CWD: ${cwd}`;
+  }
+  return `[auto-announce] Peer online oldu. CWD: ${cwd}`;
+}
+
 // --- Startup ---
 
 async function main() {
@@ -494,9 +513,10 @@ async function main() {
     git_root: myGitRoot,
     tty,
     summary: initialSummary,
+    role: MY_ROLE,
   });
   myId = reg.id;
-  log(`Registered as peer ${myId}`);
+  log(`Registered as peer ${myId} (role: ${MY_ROLE || "(none)"})`);
 
   // If summary generation is still running, update it when done
   if (!initialSummary) {
@@ -516,10 +536,39 @@ async function main() {
   await mcp.connect(new StdioServerTransport());
   log("MCP connected");
 
-  // 6. Start polling for inbound messages
+  // 6. Auto-announce to coordinator(s)
+  if (MY_ROLE && myId) {
+    try {
+      const peers = await brokerFetch<Peer[]>("/list-peers", {
+        scope: myGitRoot ? "repo" : "directory",
+        cwd: myCwd,
+        git_root: myGitRoot,
+        exclude_id: myId,
+      });
+
+      const coordinators = findCoordinators(peers);
+      if (coordinators.length > 0) {
+        const announceMsg = buildAnnounceMessage(MY_ROLE, myCwd);
+        for (const coord of coordinators) {
+          await brokerFetch("/send-message", {
+            from_id: myId,
+            to_id: coord.id,
+            text: announceMsg,
+          });
+          log(`Auto-announced to coordinator ${coord.id} (role: ${coord.role})`);
+        }
+      } else {
+        log("No coordinator found for auto-announce");
+      }
+    } catch (e) {
+      log(`Auto-announce failed (non-critical): ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // 7. Start polling for inbound messages
   const pollTimer = setInterval(pollAndPushMessages, POLL_INTERVAL_MS);
 
-  // 7. Start heartbeat
+  // 8. Start heartbeat
   const heartbeatTimer = setInterval(async () => {
     if (myId) {
       try {
@@ -530,7 +579,7 @@ async function main() {
     }
   }, HEARTBEAT_INTERVAL_MS);
 
-  // 8. Clean up on exit
+  // 9. Clean up on exit
   const cleanup = async () => {
     clearInterval(pollTimer);
     clearInterval(heartbeatTimer);
@@ -549,7 +598,9 @@ async function main() {
   process.on("SIGTERM", cleanup);
 }
 
-main().catch((e) => {
-  log(`Fatal: ${e instanceof Error ? e.message : String(e)}`);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((e) => {
+    log(`Fatal: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  });
+}

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,7 @@ import {
   getGitBranch,
   getRecentFiles,
 } from "./shared/summarize.ts";
+import { spawnPeersInGhostty } from "./shared/spawner.ts";
 
 // --- Configuration ---
 
@@ -228,6 +229,33 @@ const TOOLS = [
       properties: {},
     },
   },
+  {
+    name: "spawn_peers",
+    description:
+      "Spawn Claude Code instances in Ghostty terminal splits with assigned roles. Opens a new tab, splits it based on peer count (2=side by side, 3=L-shape, 4=grid), and starts each Claude with the given role. macOS + Ghostty 1.3+ required.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        roles: {
+          type: "array" as const,
+          items: { type: "string" as const },
+          description:
+            'Roles to assign to spawned peers (e.g. ["frontend-dev", "backend-dev"]). Max 4.',
+        },
+        prompt: {
+          type: "string" as const,
+          description:
+            "Optional startup prompt sent to each spawned Claude instance via --prompt flag.",
+        },
+        working_directory: {
+          type: "string" as const,
+          description:
+            "Working directory for spawned instances. Defaults to this instance's CWD.",
+        },
+      },
+      required: ["roles"],
+    },
+  },
 ];
 
 // --- Tool handlers ---
@@ -389,6 +417,45 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
             {
               type: "text" as const,
               text: `Error checking messages: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "spawn_peers": {
+      const { roles, prompt, working_directory } = args as {
+        roles: string[];
+        prompt?: string;
+        working_directory?: string;
+      };
+      try {
+        const result = await spawnPeersInGhostty({
+          roles,
+          cwd: working_directory ?? myCwd,
+          prompt,
+        });
+        if (!result.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to spawn peers: ${result.error}` }],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Spawned ${result.spawned_roles!.length} peer(s) in Ghostty: ${result.spawned_roles!.join(", ")}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error spawning peers: ${e instanceof Error ? e.message : String(e)}`,
             },
           ],
           isError: true,

--- a/shared/spawner.ts
+++ b/shared/spawner.ts
@@ -25,9 +25,9 @@ export interface SpawnResult {
 export function buildClaudeCommand(role: string, prompt?: string): string {
   let cmd = `CLAUDE_PEERS_ROLE="${role}" claude --dangerously-skip-permissions --dangerously-load-development-channels server:claude-peers`;
   if (prompt) {
-    // Escape double quotes in prompt
-    const escaped = prompt.replace(/"/g, '\\"');
-    cmd += ` --prompt "${escaped}"`;
+    // Escape single quotes in prompt for shell safety
+    const escaped = prompt.replace(/'/g, "'\\''");
+    cmd += ` '${escaped}'`;
   }
   return cmd;
 }

--- a/shared/spawner.ts
+++ b/shared/spawner.ts
@@ -48,54 +48,59 @@ export function generateAppleScript(config: SpawnConfig): string {
   // Escape backslashes and quotes for AppleScript string literals
   const escapeCwd = cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 
+  // cd command to set working directory (since surface configuration is unreliable)
+  const cdCmd = `cd "${escapeCwd}"`;
+
   const lines: string[] = [
     'tell application "Ghostty"',
     "  activate",
-    "  set cfg to make new surface configuration",
-    `  set initial working directory of cfg to "${escapeCwd}"`,
     "",
   ];
 
   if (roles.length === 1) {
     lines.push(
-      "  set t1 to new tab in front window with configuration cfg",
-      `  input text "${escapeAS(commands[0])}" to t1`,
+      "  set newTab to new tab in front window",
+      "  set t1 to focused terminal of newTab",
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[0])}" to t1`,
       '  send key "enter" to t1',
     );
   } else if (roles.length === 2) {
     lines.push(
-      "  set t1 to new tab in front window with configuration cfg",
-      "  set t2 to split t1 direction right with configuration cfg",
-      `  input text "${escapeAS(commands[0])}" to t1`,
+      "  set newTab to new tab in front window",
+      "  set t1 to focused terminal of newTab",
+      "  set t2 to split t1 direction right",
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[0])}" to t1`,
       '  send key "enter" to t1',
-      `  input text "${escapeAS(commands[1])}" to t2`,
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[1])}" to t2`,
       '  send key "enter" to t2',
     );
   } else if (roles.length === 3) {
     lines.push(
-      "  set t1 to new tab in front window with configuration cfg",
-      "  set t2 to split t1 direction right with configuration cfg",
-      "  set t3 to split t1 direction down with configuration cfg",
-      `  input text "${escapeAS(commands[0])}" to t1`,
+      "  set newTab to new tab in front window",
+      "  set t1 to focused terminal of newTab",
+      "  set t2 to split t1 direction right",
+      "  set t3 to split t1 direction down",
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[0])}" to t1`,
       '  send key "enter" to t1',
-      `  input text "${escapeAS(commands[1])}" to t2`,
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[1])}" to t2`,
       '  send key "enter" to t2',
-      `  input text "${escapeAS(commands[2])}" to t3`,
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[2])}" to t3`,
       '  send key "enter" to t3',
     );
   } else if (roles.length >= 4) {
     lines.push(
-      "  set t1 to new tab in front window with configuration cfg",
-      "  set t2 to split t1 direction right with configuration cfg",
-      "  set t3 to split t1 direction down with configuration cfg",
-      "  set t4 to split t2 direction down with configuration cfg",
-      `  input text "${escapeAS(commands[0])}" to t1`,
+      "  set newTab to new tab in front window",
+      "  set t1 to focused terminal of newTab",
+      "  set t2 to split t1 direction right",
+      "  set t3 to split t1 direction down",
+      "  set t4 to split t2 direction down",
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[0])}" to t1`,
       '  send key "enter" to t1',
-      `  input text "${escapeAS(commands[1])}" to t2`,
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[1])}" to t2`,
       '  send key "enter" to t2',
-      `  input text "${escapeAS(commands[2])}" to t3`,
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[2])}" to t3`,
       '  send key "enter" to t3',
-      `  input text "${escapeAS(commands[3])}" to t4`,
+      `  input text "${escapeAS(cdCmd)} && ${escapeAS(commands[3])}" to t4`,
       '  send key "enter" to t4',
     );
   }

--- a/shared/spawner.ts
+++ b/shared/spawner.ts
@@ -1,0 +1,175 @@
+/**
+ * Ghostty terminal spawner for Claude Code peers.
+ *
+ * Uses Ghostty's AppleScript API (1.3+) to open tabs, split panes,
+ * and start Claude Code instances with assigned roles.
+ *
+ * macOS only — requires Ghostty and osascript.
+ */
+
+export interface SpawnConfig {
+  roles: string[];
+  cwd: string;
+  prompt?: string;
+}
+
+export interface SpawnResult {
+  ok: boolean;
+  error?: string;
+  spawned_roles?: string[];
+}
+
+/**
+ * Build the claude command string for a given role.
+ */
+export function buildClaudeCommand(role: string, prompt?: string): string {
+  let cmd = `CLAUDE_PEERS_ROLE="${role}" claude --dangerously-skip-permissions --dangerously-load-development-channels server:claude-peers`;
+  if (prompt) {
+    // Escape double quotes in prompt
+    const escaped = prompt.replace(/"/g, '\\"');
+    cmd += ` --prompt "${escaped}"`;
+  }
+  return cmd;
+}
+
+/**
+ * Generate AppleScript to spawn peers in Ghostty splits.
+ *
+ * Layout strategy:
+ * - 1 peer: single pane
+ * - 2 peers: right split (side by side)
+ * - 3 peers: right split, then down split on left
+ * - 4 peers: right split, then down split on both
+ */
+export function generateAppleScript(config: SpawnConfig): string {
+  const { roles, cwd, prompt } = config;
+  const commands = roles.map((role) => buildClaudeCommand(role, prompt));
+
+  // Escape backslashes and quotes for AppleScript string literals
+  const escapeCwd = cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+  const lines: string[] = [
+    'tell application "Ghostty"',
+    "  activate",
+    "  set cfg to make new surface configuration",
+    `  set initial working directory of cfg to "${escapeCwd}"`,
+    "",
+  ];
+
+  if (roles.length === 1) {
+    lines.push(
+      "  set t1 to new tab in front window with configuration cfg",
+      `  input text "${escapeAS(commands[0])}" to t1`,
+      '  send key "enter" to t1',
+    );
+  } else if (roles.length === 2) {
+    lines.push(
+      "  set t1 to new tab in front window with configuration cfg",
+      "  set t2 to split t1 direction right with configuration cfg",
+      `  input text "${escapeAS(commands[0])}" to t1`,
+      '  send key "enter" to t1',
+      `  input text "${escapeAS(commands[1])}" to t2`,
+      '  send key "enter" to t2',
+    );
+  } else if (roles.length === 3) {
+    lines.push(
+      "  set t1 to new tab in front window with configuration cfg",
+      "  set t2 to split t1 direction right with configuration cfg",
+      "  set t3 to split t1 direction down with configuration cfg",
+      `  input text "${escapeAS(commands[0])}" to t1`,
+      '  send key "enter" to t1',
+      `  input text "${escapeAS(commands[1])}" to t2`,
+      '  send key "enter" to t2',
+      `  input text "${escapeAS(commands[2])}" to t3`,
+      '  send key "enter" to t3',
+    );
+  } else if (roles.length >= 4) {
+    lines.push(
+      "  set t1 to new tab in front window with configuration cfg",
+      "  set t2 to split t1 direction right with configuration cfg",
+      "  set t3 to split t1 direction down with configuration cfg",
+      "  set t4 to split t2 direction down with configuration cfg",
+      `  input text "${escapeAS(commands[0])}" to t1`,
+      '  send key "enter" to t1',
+      `  input text "${escapeAS(commands[1])}" to t2`,
+      '  send key "enter" to t2',
+      `  input text "${escapeAS(commands[2])}" to t3`,
+      '  send key "enter" to t3',
+      `  input text "${escapeAS(commands[3])}" to t4`,
+      '  send key "enter" to t4',
+    );
+  }
+
+  lines.push("end tell");
+  return lines.join("\n");
+}
+
+/**
+ * Escape a string for use inside AppleScript double-quoted string.
+ */
+function escapeAS(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Check if Ghostty is running on macOS.
+ */
+async function isGhosttyRunning(): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(
+      ["osascript", "-e", 'tell application "System Events" to (name of processes) contains "Ghostty"'],
+      { stdout: "pipe", stderr: "ignore" },
+    );
+    const text = await new Response(proc.stdout).text();
+    await proc.exited;
+    return text.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Spawn Claude Code peers in Ghostty terminal splits.
+ */
+export async function spawnPeersInGhostty(config: SpawnConfig): Promise<SpawnResult> {
+  // Platform check
+  if (process.platform !== "darwin") {
+    return { ok: false, error: "spawn_peers requires macOS with Ghostty" };
+  }
+
+  // Validate roles
+  if (config.roles.length === 0) {
+    return { ok: false, error: "At least one role is required" };
+  }
+  if (config.roles.length > 4) {
+    return { ok: false, error: "Maximum 4 roles supported per spawn" };
+  }
+
+  // Check Ghostty
+  if (!(await isGhosttyRunning())) {
+    return { ok: false, error: "Ghostty is not running" };
+  }
+
+  // Generate and execute AppleScript
+  const script = generateAppleScript(config);
+
+  try {
+    const proc = Bun.spawn(["osascript", "-e", script], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      return { ok: false, error: `AppleScript failed: ${stderr.trim()}` };
+    }
+
+    return { ok: true, spawned_roles: config.roles };
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Failed to execute osascript: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -8,6 +8,7 @@ export interface Peer {
   git_root: string | null;
   tty: string | null;
   summary: string;
+  role: string;
   registered_at: string; // ISO timestamp
   last_seen: string; // ISO timestamp
 }
@@ -29,6 +30,7 @@ export interface RegisterRequest {
   git_root: string | null;
   tty: string | null;
   summary: string;
+  role: string;
 }
 
 export interface RegisterResponse {

--- a/tests/auto-announce.test.ts
+++ b/tests/auto-announce.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "bun:test";
+import type { Peer } from "../shared/types.ts";
+import { findCoordinators, buildAnnounceMessage } from "../server.ts";
+
+test("findCoordinators returns peers with coordinator role", () => {
+  const peers: Peer[] = [
+    {
+      id: "coord1", pid: 100, cwd: "/project", git_root: "/project",
+      tty: null, summary: "Koordinatör", role: "koordinator",
+      registered_at: new Date().toISOString(), last_seen: new Date().toISOString(),
+    },
+    {
+      id: "worker1", pid: 200, cwd: "/project", git_root: "/project",
+      tty: null, summary: "Frontend dev", role: "frontend-dev",
+      registered_at: new Date().toISOString(), last_seen: new Date().toISOString(),
+    },
+  ];
+
+  const coordinators = findCoordinators(peers);
+  expect(coordinators).toHaveLength(1);
+  expect(coordinators[0].id).toBe("coord1");
+});
+
+test("findCoordinators matches coordinator and koordinator roles", () => {
+  const peers: Peer[] = [
+    { id: "c1", pid: 100, cwd: "/p", git_root: "/p", tty: null, summary: "", role: "coordinator", registered_at: "", last_seen: "" },
+    { id: "c2", pid: 101, cwd: "/p", git_root: "/p", tty: null, summary: "", role: "koordinator", registered_at: "", last_seen: "" },
+    { id: "w1", pid: 200, cwd: "/p", git_root: "/p", tty: null, summary: "", role: "backend-dev", registered_at: "", last_seen: "" },
+  ];
+
+  const coordinators = findCoordinators(peers);
+  expect(coordinators).toHaveLength(2);
+});
+
+test("findCoordinators returns empty when no coordinator exists", () => {
+  const peers: Peer[] = [
+    { id: "w1", pid: 200, cwd: "/p", git_root: "/p", tty: null, summary: "", role: "frontend-dev", registered_at: "", last_seen: "" },
+  ];
+
+  const coordinators = findCoordinators(peers);
+  expect(coordinators).toHaveLength(0);
+});
+
+test("buildAnnounceMessage includes role and cwd", () => {
+  const msg = buildAnnounceMessage("frontend-dev", "/Users/me/project-x");
+  expect(msg).toContain("frontend-dev");
+  expect(msg).toContain("/Users/me/project-x");
+  expect(msg).toContain("online");
+});
+
+test("buildAnnounceMessage with empty role", () => {
+  const msg = buildAnnounceMessage("", "/Users/me/project-x");
+  expect(msg).toContain("/Users/me/project-x");
+  expect(msg).toContain("online");
+  expect(msg).not.toContain("Rol:");
+});

--- a/tests/broker.test.ts
+++ b/tests/broker.test.ts
@@ -1,0 +1,96 @@
+import { test, expect, beforeAll, afterAll } from "bun:test";
+
+const TEST_PORT = 17899;
+const TEST_DB = `/tmp/claude-peers-test-${Date.now()}.db`;
+const BROKER_URL = `http://127.0.0.1:${TEST_PORT}`;
+
+let brokerProc: ReturnType<typeof Bun.spawn>;
+
+beforeAll(async () => {
+  brokerProc = Bun.spawn(["bun", "broker.ts"], {
+    cwd: import.meta.dir + "/..",
+    env: {
+      ...process.env,
+      CLAUDE_PEERS_PORT: String(TEST_PORT),
+      CLAUDE_PEERS_DB: TEST_DB,
+    },
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+
+  for (let i = 0; i < 30; i++) {
+    try {
+      const res = await fetch(`${BROKER_URL}/health`, { signal: AbortSignal.timeout(500) });
+      if (res.ok) break;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 200));
+  }
+});
+
+afterAll(() => {
+  brokerProc.kill();
+  try { require("fs").unlinkSync(TEST_DB); } catch {}
+});
+
+test("register peer with role", async () => {
+  const res = await fetch(`${BROKER_URL}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      pid: process.pid,
+      cwd: "/tmp/test-project",
+      git_root: "/tmp/test-project",
+      tty: null,
+      summary: "Test peer",
+      role: "frontend-dev",
+    }),
+  });
+  const data = await res.json() as { id: string };
+  expect(data.id).toBeDefined();
+  expect(typeof data.id).toBe("string");
+  expect(data.id.length).toBe(8);
+});
+
+test("list peers returns role field", async () => {
+  const res = await fetch(`${BROKER_URL}/list-peers`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      scope: "machine",
+      cwd: "/",
+      git_root: null,
+    }),
+  });
+  const peers = await res.json() as Array<{ id: string; role: string }>;
+  expect(peers.length).toBeGreaterThan(0);
+
+  const peer = peers.find((p) => p.role === "frontend-dev");
+  expect(peer).toBeDefined();
+  expect(peer!.role).toBe("frontend-dev");
+});
+
+test("register peer without role defaults to empty string", async () => {
+  const res = await fetch(`${BROKER_URL}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      pid: process.pid + 1,
+      cwd: "/tmp/test-project-2",
+      git_root: null,
+      tty: null,
+      summary: "",
+      role: "",
+    }),
+  });
+  const data = await res.json() as { id: string };
+
+  const listRes = await fetch(`${BROKER_URL}/list-peers`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ scope: "machine", cwd: "/", git_root: null }),
+  });
+  const peers = await listRes.json() as Array<{ id: string; role: string }>;
+  const peer = peers.find((p) => p.id === data.id);
+  expect(peer).toBeDefined();
+  expect(peer!.role).toBe("");
+});

--- a/tests/spawner.test.ts
+++ b/tests/spawner.test.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "bun:test";
+import { buildClaudeCommand, generateAppleScript } from "../shared/spawner.ts";
+import type { SpawnConfig } from "../shared/spawner.ts";
+
+test("buildClaudeCommand with role only", () => {
+  const cmd = buildClaudeCommand("frontend-dev");
+  expect(cmd).toContain('CLAUDE_PEERS_ROLE="frontend-dev"');
+  expect(cmd).toContain("--dangerously-skip-permissions");
+  expect(cmd).toContain("--dangerously-load-development-channels server:claude-peers");
+  expect(cmd).not.toContain("--prompt");
+});
+
+test("buildClaudeCommand with prompt", () => {
+  const cmd = buildClaudeCommand("backend-dev", "Koordinatöre bağlan");
+  expect(cmd).toContain('CLAUDE_PEERS_ROLE="backend-dev"');
+  expect(cmd).toContain('--prompt "Koordinatöre bağlan"');
+});
+
+test("buildClaudeCommand escapes quotes in prompt", () => {
+  const cmd = buildClaudeCommand("dev", 'say "hello"');
+  expect(cmd).toContain('--prompt "say \\"hello\\""');
+});
+
+test("generateAppleScript for 1 peer", () => {
+  const config: SpawnConfig = { roles: ["frontend-dev"], cwd: "/tmp/project" };
+  const script = generateAppleScript(config);
+
+  expect(script).toContain('tell application "Ghostty"');
+  expect(script).toContain("activate");
+  expect(script).toContain('set initial working directory of cfg to "/tmp/project"');
+  expect(script).toContain("new tab in front window");
+  expect(script).toContain("frontend-dev");
+  expect(script).not.toContain("split");
+  expect(script).toContain("end tell");
+});
+
+test("generateAppleScript for 2 peers creates right split", () => {
+  const config: SpawnConfig = {
+    roles: ["frontend-dev", "backend-dev"],
+    cwd: "/tmp/project",
+  };
+  const script = generateAppleScript(config);
+
+  expect(script).toContain("split t1 direction right");
+  expect(script).toContain("frontend-dev");
+  expect(script).toContain("backend-dev");
+  // Should have exactly 1 split
+  expect(script.match(/split/g)?.length).toBe(1);
+});
+
+test("generateAppleScript for 3 peers creates right + down splits", () => {
+  const config: SpawnConfig = {
+    roles: ["frontend-dev", "backend-dev", "test-dev"],
+    cwd: "/tmp/project",
+  };
+  const script = generateAppleScript(config);
+
+  expect(script).toContain("split t1 direction right");
+  expect(script).toContain("split t1 direction down");
+  expect(script.match(/split/g)?.length).toBe(2);
+  expect(script).toContain("frontend-dev");
+  expect(script).toContain("backend-dev");
+  expect(script).toContain("test-dev");
+});
+
+test("generateAppleScript for 4 peers creates 2x2 grid", () => {
+  const config: SpawnConfig = {
+    roles: ["frontend-dev", "backend-dev", "test-dev", "devops"],
+    cwd: "/tmp/project",
+  };
+  const script = generateAppleScript(config);
+
+  expect(script).toContain("split t1 direction right");
+  expect(script).toContain("split t1 direction down");
+  expect(script).toContain("split t2 direction down");
+  expect(script.match(/split/g)?.length).toBe(3);
+});
+
+test("generateAppleScript with prompt includes --prompt flag", () => {
+  const config: SpawnConfig = {
+    roles: ["frontend-dev"],
+    cwd: "/tmp/project",
+    prompt: "Görevini al",
+  };
+  const script = generateAppleScript(config);
+
+  expect(script).toContain("--prompt");
+  expect(script).toContain("Görevini al");
+});
+
+test("generateAppleScript escapes CWD with spaces", () => {
+  const config: SpawnConfig = {
+    roles: ["dev"],
+    cwd: "/Users/me/My Projects/app",
+  };
+  const script = generateAppleScript(config);
+
+  expect(script).toContain("/Users/me/My Projects/app");
+});

--- a/tests/spawner.test.ts
+++ b/tests/spawner.test.ts
@@ -10,15 +10,16 @@ test("buildClaudeCommand with role only", () => {
   expect(cmd).not.toContain("--prompt");
 });
 
-test("buildClaudeCommand with prompt", () => {
+test("buildClaudeCommand with prompt as positional arg", () => {
   const cmd = buildClaudeCommand("backend-dev", "Koordinatöre bağlan");
   expect(cmd).toContain('CLAUDE_PEERS_ROLE="backend-dev"');
-  expect(cmd).toContain('--prompt "Koordinatöre bağlan"');
+  expect(cmd).toContain("server:claude-peers 'Koordinatöre bağlan'");
+  expect(cmd).not.toContain("--prompt");
 });
 
-test("buildClaudeCommand escapes quotes in prompt", () => {
-  const cmd = buildClaudeCommand("dev", 'say "hello"');
-  expect(cmd).toContain('--prompt "say \\"hello\\""');
+test("buildClaudeCommand escapes single quotes in prompt", () => {
+  const cmd = buildClaudeCommand("dev", "it's a test");
+  expect(cmd).toContain("'it'\\''s a test'");
 });
 
 test("generateAppleScript for 1 peer", () => {
@@ -78,7 +79,7 @@ test("generateAppleScript for 4 peers creates 2x2 grid", () => {
   expect(script.match(/split/g)?.length).toBe(3);
 });
 
-test("generateAppleScript with prompt includes --prompt flag", () => {
+test("generateAppleScript with prompt includes positional arg", () => {
   const config: SpawnConfig = {
     roles: ["frontend-dev"],
     cwd: "/tmp/project",
@@ -86,7 +87,7 @@ test("generateAppleScript with prompt includes --prompt flag", () => {
   };
   const script = generateAppleScript(config);
 
-  expect(script).toContain("--prompt");
+  expect(script).not.toContain("--prompt");
   expect(script).toContain("Görevini al");
 });
 

--- a/tests/spawner.test.ts
+++ b/tests/spawner.test.ts
@@ -27,8 +27,9 @@ test("generateAppleScript for 1 peer", () => {
 
   expect(script).toContain('tell application "Ghostty"');
   expect(script).toContain("activate");
-  expect(script).toContain('set initial working directory of cfg to "/tmp/project"');
+  expect(script).toContain('cd \\"/tmp/project\\"');
   expect(script).toContain("new tab in front window");
+  expect(script).toContain("focused terminal of newTab");
   expect(script).toContain("frontend-dev");
   expect(script).not.toContain("split");
   expect(script).toContain("end tell");
@@ -41,6 +42,7 @@ test("generateAppleScript for 2 peers creates right split", () => {
   };
   const script = generateAppleScript(config);
 
+  expect(script).toContain("focused terminal of newTab");
   expect(script).toContain("split t1 direction right");
   expect(script).toContain("frontend-dev");
   expect(script).toContain("backend-dev");

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "bun:test";
+import type { Peer, RegisterRequest } from "../shared/types.ts";
+
+test("Peer interface accepts role field", () => {
+  const peer: Peer = {
+    id: "abc12345",
+    pid: 1234,
+    cwd: "/tmp/test",
+    git_root: null,
+    tty: null,
+    summary: "Test peer",
+    role: "frontend-dev",
+    registered_at: new Date().toISOString(),
+    last_seen: new Date().toISOString(),
+  };
+  expect(peer.role).toBe("frontend-dev");
+});
+
+test("Peer interface accepts empty role", () => {
+  const peer: Peer = {
+    id: "abc12345",
+    pid: 1234,
+    cwd: "/tmp/test",
+    git_root: null,
+    tty: null,
+    summary: "",
+    role: "",
+    registered_at: new Date().toISOString(),
+    last_seen: new Date().toISOString(),
+  };
+  expect(peer.role).toBe("");
+});
+
+test("RegisterRequest includes role field", () => {
+  const req: RegisterRequest = {
+    pid: 1234,
+    cwd: "/tmp/test",
+    git_root: null,
+    tty: null,
+    summary: "",
+    role: "backend-dev",
+  };
+  expect(req.role).toBe("backend-dev");
+});


### PR DESCRIPTION
## Summary / Özet

**EN:** Adds a role-based identity system so Claude Code peers can be recognized automatically after restart — no manual re-introduction needed. Workers announce themselves to coordinators on startup.

**TR:** Claude Code peer'larına rol tabanlı kimlik sistemi ekler. Yeniden başlatıldıktan sonra peer'lar otomatik olarak tanınır — manuel tanıtma gerekmez. Worker'lar başlangıçta koordinatörlere kendilerini otomatik duyurur.

## Problem / Sorun

**EN:** When running multiple Claude Code instances (coordinator + workers), closing and reopening workers requires manually re-introducing each one to the coordinator ("you are the frontend dev", "you are the backend dev"). This is tedious and breaks workflow.

**TR:** Birden fazla Claude Code instance'ı çalıştırırken (koordinatör + worker'lar), worker'ları kapatıp tekrar açtığında her birini koordinatöre yeniden tanıtmak gerekiyor ("sen frontend'cisin", "sen backend'cisin"). Bu zahmetli ve iş akışını bozuyor.

## Solution / Çözüm

**EN:**
- New `CLAUDE_PEERS_ROLE` environment variable assigns a persistent role to each instance
- Role is stored in the broker's SQLite database alongside peer registration
- On startup, workers with a role automatically find and message any coordinator in the same repo
- Coordinators see each peer's role in `list_peers` output
- Shell aliases make it easy: `claude-frontend`, `claude-backend`, `claude-koordinator`

**TR:**
- Yeni `CLAUDE_PEERS_ROLE` ortam değişkeni her instance'a kalıcı bir rol atar
- Rol, broker'ın SQLite veritabanında peer kaydıyla birlikte saklanır
- Başlangıçta, rolü olan worker'lar aynı repo'daki koordinatörü otomatik bulup mesaj gönderir
- Koordinatörler `list_peers` çıktısında her peer'ın rolünü görür
- Shell alias'ları kullanımı kolaylaştırır: `claude-frontend`, `claude-backend`, `claude-koordinator`

## Changes / Değişiklikler

| File | Change |
|------|--------|
| `shared/types.ts` | Added `role: string` to `Peer` and `RegisterRequest` interfaces |
| `broker.ts` | Added `role` column to SQLite peers table + migration for existing DBs |
| `server.ts` | `CLAUDE_PEERS_ROLE` env var, `findCoordinators()`, `buildAnnounceMessage()`, auto-announce on startup, role in `list_peers` output, `import.meta.main` guard for testability |
| `cli.ts` | Role display in `status` and `peers` commands (e.g. `abc123 PID:456 [frontend-dev] /path`) |
| `CLAUDE.md` | Added `CLAUDE_PEERS_ROLE` to environment variables documentation |
| `README.md` | Added Roles section with usage examples and aliases |
| `CHANGELOG.md` | Added unreleased changelog entries |

## Usage / Kullanım

```bash
# Set up aliases / Alias'ları kur
alias claude-koordinator='CLAUDE_PEERS_ROLE="koordinator" claude --dangerously-load-development-channels server:claude-peers'
alias claude-frontend='CLAUDE_PEERS_ROLE="frontend-dev" claude --dangerously-load-development-channels server:claude-peers'
alias claude-backend='CLAUDE_PEERS_ROLE="backend-dev" claude --dangerously-load-development-channels server:claude-peers'

# Tab 1: Start coordinator / Koordinatörü başlat
claude-koordinator

# Tab 2: Start frontend worker / Frontend worker'ı başlat
claude-frontend
# → Coordinator automatically receives: "[auto-announce] Peer online oldu. Rol: frontend-dev, CWD: /path"
```

## Auto-Announce Flow

```
  Frontend starts → registers with role "frontend-dev"
       ↓
  Queries list_peers for coordinators in same repo
       ↓
  Finds peer with role "koordinator"
       ↓
  Sends: "[auto-announce] Peer online oldu. Rol: frontend-dev, CWD: /project"
       ↓
  Coordinator receives message instantly via channel push
```

## Test Plan

- [x] 11 tests passing (`bun test`)
- [x] Type tests: `Peer` and `RegisterRequest` accept `role` field
- [x] Broker integration tests: register with role, list peers returns role, empty role defaults
- [x] Auto-announce unit tests: `findCoordinators()` matching, `buildAnnounceMessage()` output
- [x] Manual end-to-end test: broker API role registration + message delivery verified
- [ ] Multi-instance test with real Claude Code sessions

## Backward Compatibility

- Existing databases: SQLite migration adds `role` column with `DEFAULT ''` — no data loss
- Existing peers without roles: appear with empty role string, no behavioral change
- `CLAUDE_PEERS_ROLE` is optional — everything works without it, just like before

🤖 Generated with [Claude Code](https://claude.ai/code)