### PR TITLE
fix: cross-platform path handling for broker startup

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -38,7 +38,7 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const BROKER_SCRIPT = Bun.fileURLToPath(new URL("./broker.ts", import.meta.url));
 
 // --- Broker communication ---
 
@@ -71,7 +71,7 @@ async function ensureBroker(): Promise<void> {
   }
 
   log("Starting broker daemon...");
-  const proc = Bun.spawn(["bun", BROKER_SCRIPT], {
+  const proc = Bun.spawn([process.execPath, BROKER_SCRIPT], {
     stdio: ["ignore", "ignore", "inherit"],
     // Detach so the broker survives if this MCP server exits
     // On macOS/Linux, the broker will keep running


### PR DESCRIPTION
## Summary

- Replace `.pathname` with `Bun.fileURLToPath()` for correct URL-to-path conversion
- Replace hardcoded `"bun"` with `process.execPath` for reliable binary resolution

## Problem

On Windows, `new URL(...).pathname` returns a URL-encoded path like `/C:/Users/...` (with a leading slash and potential percent-encoding), which causes the broker process to fail to start.

Similarly, hardcoding `"bun"` assumes it's in PATH, which isn't always the case.

## Fix

`Bun.fileURLToPath()` correctly converts file URLs to OS-native paths on all platforms. `process.execPath` resolves to the actual Bun binary path at runtime, making it reliable regardless of PATH configuration.

Both changes are safe on macOS/Linux as well — this is a strict improvement for all platforms.

## Tested on

- Windows 11 ✅ (confirmed working)