### PR TITLE
fix: use --git-common-dir for worktree-compatible repo scope

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -100,7 +100,7 @@ function log(msg: string) {
 
 async function getGitRoot(cwd: string): Promise<string | null> {
   try {
-    const proc = Bun.spawn(["git", "rev-parse", "--show-toplevel"], {
+    const proc = Bun.spawn(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], {
       cwd,
       stdout: "pipe",
       stderr: "ignore",


### PR DESCRIPTION
Closes #23

## Problem

`list_peers` with `scope: "repo"` does not find peers running in different git worktrees of the same repository.

`getGitRoot()` uses `git rev-parse --show-toplevel`, which returns a different path for each worktree:

```
# main repo
git rev-parse --show-toplevel
# → /path/to/repo

# worktree
git rev-parse --show-toplevel
# → /path/to/worktrees/feat/my-feature  ← different!
```

Since the broker compares `git_root` with exact string matching (`SELECT * FROM peers WHERE git_root = ?`), peers in different worktrees are never matched.

## Fix

Replace `--show-toplevel` with `--path-format=absolute --git-common-dir`, which returns the shared `.git` directory consistent across all worktrees:

```
# main repo
git rev-parse --path-format=absolute --git-common-dir
# → /path/to/repo/.git

# any worktree
git rev-parse --path-format=absolute --git-common-dir
# → /path/to/repo/.git  ← same!
```

## Verified

Tested locally with 6 peers (1 main repo + 5 worktrees). After the fix, `repo` scope correctly discovers all peers.
