### PR TITLE
feat: cross-machine peer support via CLAUDE_PEERS_BROKER_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,54 @@ bun cli.ts send <id> <msg>   # send a message into a Claude session
 bun cli.ts kill-broker       # stop the broker
 ```
 
+## Cross-machine setup
+
+By default the broker binds to `localhost:7899`, so peers on other machines can't reach it. To connect Claude Code instances across machines (e.g. Mac laptop + Linux server):
+
+**On the machine running the broker (server):**
+
+The broker already binds `0.0.0.0:7899` — make sure that port is reachable from the client machine (firewall, VPN, etc.).
+
+**On the remote machine (client):**
+
+Set `CLAUDE_PEERS_BROKER_URL` to point at the server when registering the MCP server:
+
+```bash
+claude mcp add --scope user --transport stdio claude-peers \
+  -- env CLAUDE_PEERS_BROKER_URL=http://SERVER_IP:7899 bun ~/claude-peers-mcp/server.ts
+```
+
+Or add it directly to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "claude-peers": {
+      "type": "stdio",
+      "command": "bun",
+      "args": ["/path/to/claude-peers-mcp/server.ts"],
+      "env": {
+        "CLAUDE_PEERS_BROKER_URL": "http://SERVER_IP:7899"
+      }
+    }
+  }
+}
+```
+
+Both instances will now share the same broker and appear in each other's `list_peers` results.
+
+> **Gotcha:** `send_message` takes `to_id` (not `to`) as the parameter name. Passing the wrong key silently fails.
+
+> **Best practice:** Call `set_summary` at the start of each session so peers immediately know your context when they run `list_peers`.
+
 ## Configuration
 
-| Environment variable | Default              | Description                           |
-| -------------------- | -------------------- | ------------------------------------- |
-| `CLAUDE_PEERS_PORT`  | `7899`               | Broker port                           |
-| `CLAUDE_PEERS_DB`    | `~/.claude-peers.db` | SQLite database path                  |
-| `OPENAI_API_KEY`     | —                    | Enables auto-summary via gpt-5.4-nano |
+| Environment variable      | Default              | Description                                  |
+| ------------------------- | -------------------- | -------------------------------------------- |
+| `CLAUDE_PEERS_PORT`       | `7899`               | Broker port                                  |
+| `CLAUDE_PEERS_DB`         | `~/.claude-peers.db` | SQLite database path                         |
+| `CLAUDE_PEERS_BROKER_URL` | `http://127.0.0.1:7899` | Broker URL (override for cross-machine)   |
+| `OPENAI_API_KEY`          | —                    | Enables auto-summary via gpt-5.4-nano        |
 
 ## Requirements
 

--- a/broker.ts
+++ b/broker.ts
@@ -39,6 +39,7 @@ db.run(`
     cwd TEXT NOT NULL,
     git_root TEXT,
     tty TEXT,
+    hostname TEXT NOT NULL DEFAULT 'localhost',
     summary TEXT NOT NULL DEFAULT '',
     registered_at TEXT NOT NULL,
     last_seen TEXT NOT NULL
@@ -60,15 +61,24 @@ db.run(`
 
 // Clean up stale peers (PIDs that no longer exist) on startup
 function cleanStalePeers() {
-  const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
+  const peers = db.query("SELECT id, pid, hostname, last_seen FROM peers").all() as { id: string; pid: number; hostname: string; last_seen: string }[];
+  const localHostname = require("os").hostname();
   for (const peer of peers) {
-    try {
-      // Check if process is still alive (signal 0 doesn't kill, just checks)
-      process.kill(peer.pid, 0);
-    } catch {
-      // Process doesn't exist, remove it
-      db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
-      db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
+    if (peer.hostname === "localhost" || peer.hostname === localHostname) {
+      // Local peer — check if PID is alive
+      try {
+        process.kill(peer.pid, 0);
+      } catch {
+        db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
+        db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
+      }
+    } else {
+      // Remote peer — expire if no heartbeat for 60s
+      const lastSeen = new Date(peer.last_seen).getTime();
+      if (Date.now() - lastSeen > 60_000) {
+        db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
+        db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
+      }
     }
   }
 }
@@ -81,8 +91,8 @@ setInterval(cleanStalePeers, 30_000);
 // --- Prepared statements ---
 
 const insertPeer = db.prepare(`
-  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, registered_at, last_seen)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO peers (id, pid, cwd, git_root, tty, hostname, summary, registered_at, last_seen)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateLastSeen = db.prepare(`
@@ -145,7 +155,8 @@ function handleRegister(body: RegisterRequest): RegisterResponse {
     deletePeer.run(existing.id);
   }
 
-  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now);
+  const hostname = (body as any).hostname ?? "localhost";
+  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, hostname, body.summary, now, now);
   return { id };
 }
 
@@ -184,13 +195,18 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
     peers = peers.filter((p) => p.id !== body.exclude_id);
   }
 
-  // Verify each peer's process is still alive
+  // Verify each peer's process is still alive (local only)
+  const localHostname = require("os").hostname();
   return peers.filter((p) => {
+    const ph = (p as any).hostname ?? "localhost";
+    if (ph !== "localhost" && ph !== localHostname) {
+      // Remote peer — trust heartbeat-based expiry
+      return true;
+    }
     try {
       process.kill(p.pid, 0);
       return true;
     } catch {
-      // Clean up dead peer
       deletePeer.run(p.id);
       return false;
     }
@@ -227,7 +243,7 @@ function handleUnregister(body: { id: string }): void {
 
 Bun.serve({
   port: PORT,
-  hostname: "127.0.0.1",
+  hostname: process.env.CLAUDE_PEERS_BIND ?? "0.0.0.0",
   async fetch(req) {
     const url = new URL(req.url);
     const path = url.pathname;
@@ -270,4 +286,5 @@ Bun.serve({
   },
 });
 
-console.error(`[claude-peers broker] listening on 127.0.0.1:${PORT} (db: ${DB_PATH})`);
+const BIND = process.env.CLAUDE_PEERS_BIND ?? "0.0.0.0";
+console.error(`[claude-peers broker] listening on ${BIND}:${PORT} (db: ${DB_PATH})`);

--- a/server.ts
+++ b/server.ts
@@ -35,7 +35,7 @@ import {
 // --- Configuration ---
 
 const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
-const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
+const BROKER_URL = process.env.CLAUDE_PEERS_BROKER_URL ?? `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
@@ -493,6 +493,7 @@ async function main() {
     cwd: myCwd,
     git_root: myGitRoot,
     tty,
+    hostname: require("os").hostname(),
     summary: initialSummary,
   });
   myId = reg.id;


### PR DESCRIPTION
## Summary

- **broker.ts**: bind to `0.0.0.0` by default (override with `CLAUDE_PEERS_BIND`), add `hostname` column to peers table, use heartbeat-based expiry for remote peers instead of PID check
- **server.ts**: respect `CLAUDE_PEERS_BROKER_URL` env var, send hostname on register
- **README.md**: new "Cross-machine setup" section with step-by-step instructions, `~/.claude.json` config example, `CLAUDE_PEERS_BROKER_URL` added to config table, `to_id` gotcha, and `set_summary` best practice

## Motivation

Previously the broker hardcoded `127.0.0.1`, making cross-machine setups impossible without manual patching. This was discovered while connecting a Mac client to a Linux server — the fix was straightforward but the env vars and peer-expiry logic needed updating to handle remote peers correctly.

## Test plan

- [ ] Single-machine setup still works (broker defaults, no env vars needed)
- [ ] Remote client with `CLAUDE_PEERS_BROKER_URL=http://SERVER_IP:7899` appears in `list_peers` on both sides
- [ ] Remote peers expire after 60s of no heartbeat rather than failing on PID check
- [ ] `CLAUDE_PEERS_BIND=127.0.0.1` can lock the broker back to localhost-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)