### PR TITLE
Add multicast group messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The other Claude receives it immediately and responds.
 
 ## What Claude can do
 
+### Unicast (one-to-one)
+
 | Tool             | What it does                                                                   |
 | ---------------- | ------------------------------------------------------------------------------ |
 | `list_peers`     | Find other Claude Code instances — scoped to `machine`, `directory`, or `repo` |
@@ -68,9 +70,27 @@ The other Claude receives it immediately and responds.
 | `set_summary`    | Describe what you're working on (visible to other peers)                       |
 | `check_messages` | Manually check for messages (fallback if not using channel mode)               |
 
+### Multicast (groups)
+
+| Tool                 | What it does                                                              |
+| -------------------- | ------------------------------------------------------------------------- |
+| `create_group`       | Create a named group for multicast messaging                              |
+| `join_group`         | Join a group (membership persists across sessions via working directory)   |
+| `leave_group`        | Leave a group                                                             |
+| `list_groups`        | List groups and their members (online/offline status)                     |
+| `send_group_message` | Send a message to all active group members (sender excluded)              |
+
+**How groups work:** Groups are named and persistent. Membership is tied to your working directory (CWD), not your ephemeral peer ID — so when a Claude instance restarts, it automatically rejoins its groups. A `send_group_message` fans out into individual unicast messages at the broker, so the existing delivery pipeline handles everything.
+
+**Quadratic explosion warning:** With N group members, one group message creates N-1 deliveries. If everyone replies to the group, that's N×(N-1) messages. Use groups for announcements and coordination; use `send_message` for conversations between two peers.
+
+Group messages include `group_name` in the channel notification metadata, so the receiving Claude knows to reply with `send_group_message` (to the group) rather than `send_message` (to the individual sender).
+
 ## How it works
 
 A **broker daemon** runs on `localhost:7899` with a SQLite database. Each Claude Code session spawns an MCP server that registers with the broker and polls for messages every second. Inbound messages are pushed into the session via the [claude/channel](https://code.claude.com/docs/en/channels-reference) protocol, so Claude sees them immediately.
+
+The broker also manages **groups** for multicast messaging. Group membership is keyed by working directory (CWD), which is stable across sessions. When a peer registers, the broker automatically links it to any groups its CWD belongs to. Group messages are fanned out into individual unicast messages in the existing `messages` table — no separate delivery path needed.
 
 ```
                     ┌───────────────────────────┐

--- a/broker.ts
+++ b/broker.ts
@@ -21,6 +21,13 @@ import type {
   PollMessagesResponse,
   Peer,
   Message,
+  CreateGroupRequest,
+  JoinGroupRequest,
+  LeaveGroupRequest,
+  ListGroupsRequest,
+  SendGroupMessageRequest,
+  Group,
+  GroupMember,
 } from "./shared/types.ts";
 
 const PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
@@ -53,8 +60,31 @@ db.run(`
     text TEXT NOT NULL,
     sent_at TEXT NOT NULL,
     delivered INTEGER NOT NULL DEFAULT 0,
+    group_name TEXT,
     FOREIGN KEY (from_id) REFERENCES peers(id),
     FOREIGN KEY (to_id) REFERENCES peers(id)
+  )
+`);
+
+// Migration: add group_name column to messages if upgrading from older schema
+try { db.run("ALTER TABLE messages ADD COLUMN group_name TEXT"); } catch { /* already exists */ }
+
+db.run(`
+  CREATE TABLE IF NOT EXISTS groups (
+    name TEXT PRIMARY KEY,
+    description TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+  )
+`);
+
+db.run(`
+  CREATE TABLE IF NOT EXISTS group_members (
+    group_name TEXT NOT NULL,
+    member_cwd TEXT NOT NULL,
+    active_peer_id TEXT,
+    joined_at TEXT NOT NULL,
+    PRIMARY KEY (group_name, member_cwd),
+    FOREIGN KEY (group_name) REFERENCES groups(name)
   )
 `);
 
@@ -67,6 +97,7 @@ function cleanStalePeers() {
       process.kill(peer.pid, 0);
     } catch {
       // Process doesn't exist, remove it
+      db.run("UPDATE group_members SET active_peer_id = NULL WHERE active_peer_id = ?", [peer.id]);
       db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
       db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
     }
@@ -110,8 +141,8 @@ const selectPeersByGitRoot = db.prepare(`
 `);
 
 const insertMessage = db.prepare(`
-  INSERT INTO messages (from_id, to_id, text, sent_at, delivered)
-  VALUES (?, ?, ?, ?, 0)
+  INSERT INTO messages (from_id, to_id, text, sent_at, delivered, group_name)
+  VALUES (?, ?, ?, ?, 0, ?)
 `);
 
 const selectUndelivered = db.prepare(`
@@ -146,6 +177,10 @@ function handleRegister(body: RegisterRequest): RegisterResponse {
   }
 
   insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now);
+
+  // Auto-link this peer to any groups where its CWD is a member
+  db.run("UPDATE group_members SET active_peer_id = ? WHERE member_cwd = ?", [id, body.cwd]);
+
   return { id };
 }
 
@@ -204,7 +239,7 @@ function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: str
     return { ok: false, error: `Peer ${body.to_id} not found` };
   }
 
-  insertMessage.run(body.from_id, body.to_id, body.text, new Date().toISOString());
+  insertMessage.run(body.from_id, body.to_id, body.text, new Date().toISOString(), null);
   return { ok: true };
 }
 
@@ -220,7 +255,99 @@ function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
 }
 
 function handleUnregister(body: { id: string }): void {
+  db.run("UPDATE group_members SET active_peer_id = NULL WHERE active_peer_id = ?", [body.id]);
   deletePeer.run(body.id);
+}
+
+// --- Group handlers ---
+
+function handleCreateGroup(body: CreateGroupRequest): { ok: boolean; error?: string } {
+  const existing = db.query("SELECT name FROM groups WHERE name = ?").get(body.name);
+  if (existing) {
+    return { ok: false, error: `Group '${body.name}' already exists` };
+  }
+  db.run(
+    "INSERT INTO groups (name, description, created_at) VALUES (?, ?, ?)",
+    [body.name, body.description ?? "", new Date().toISOString()]
+  );
+  return { ok: true };
+}
+
+function handleJoinGroup(body: JoinGroupRequest): { ok: boolean; error?: string } {
+  const group = db.query("SELECT name FROM groups WHERE name = ?").get(body.group_name);
+  if (!group) {
+    return { ok: false, error: `Group '${body.group_name}' not found` };
+  }
+
+  // Upsert: if this CWD is already a member, just update the active peer ID
+  const existing = db.query(
+    "SELECT member_cwd FROM group_members WHERE group_name = ? AND member_cwd = ?"
+  ).get(body.group_name, body.member_cwd);
+
+  if (existing) {
+    db.run(
+      "UPDATE group_members SET active_peer_id = ? WHERE group_name = ? AND member_cwd = ?",
+      [body.peer_id, body.group_name, body.member_cwd]
+    );
+  } else {
+    db.run(
+      "INSERT INTO group_members (group_name, member_cwd, active_peer_id, joined_at) VALUES (?, ?, ?, ?)",
+      [body.group_name, body.member_cwd, body.peer_id, new Date().toISOString()]
+    );
+  }
+  return { ok: true };
+}
+
+function handleLeaveGroup(body: LeaveGroupRequest): { ok: boolean; error?: string } {
+  const result = db.run(
+    "DELETE FROM group_members WHERE group_name = ? AND member_cwd = ?",
+    [body.group_name, body.member_cwd]
+  );
+  if (result.changes === 0) {
+    return { ok: false, error: `Not a member of group '${body.group_name}'` };
+  }
+  return { ok: true };
+}
+
+function handleListGroups(body: ListGroupsRequest): { groups: (Group & { members: GroupMember[] })[] } {
+  let groups: Group[];
+  if (body.member_cwd) {
+    groups = db.query(
+      `SELECT DISTINCT g.* FROM groups g
+       JOIN group_members gm ON g.name = gm.group_name
+       WHERE gm.member_cwd = ?`
+    ).all(body.member_cwd) as Group[];
+  } else {
+    groups = db.query("SELECT * FROM groups").all() as Group[];
+  }
+
+  return {
+    groups: groups.map((g) => ({
+      ...g,
+      members: db.query(
+        "SELECT * FROM group_members WHERE group_name = ?"
+      ).all(g.name) as GroupMember[],
+    })),
+  };
+}
+
+function handleSendGroupMessage(body: SendGroupMessageRequest): { ok: boolean; error?: string; sent_to: number } {
+  const group = db.query("SELECT name FROM groups WHERE name = ?").get(body.group_name);
+  if (!group) {
+    return { ok: false, error: `Group '${body.group_name}' not found`, sent_to: 0 };
+  }
+
+  // Fan out: insert one message per active member, excluding sender
+  const members = db.query(
+    "SELECT active_peer_id FROM group_members WHERE group_name = ? AND active_peer_id IS NOT NULL AND active_peer_id != ?"
+  ).all(body.group_name, body.from_id) as { active_peer_id: string }[];
+
+  const now = new Date().toISOString();
+  for (const member of members) {
+    insertMessage.run(body.from_id, member.active_peer_id, body.text, now, body.group_name);
+  }
+
+  return { ok: true, sent_to: members.length };
 }
 
 // --- HTTP Server ---
@@ -260,6 +387,16 @@ Bun.serve({
         case "/unregister":
           handleUnregister(body as { id: string });
           return Response.json({ ok: true });
+        case "/create-group":
+          return Response.json(handleCreateGroup(body as CreateGroupRequest));
+        case "/join-group":
+          return Response.json(handleJoinGroup(body as JoinGroupRequest));
+        case "/leave-group":
+          return Response.json(handleLeaveGroup(body as LeaveGroupRequest));
+        case "/list-groups":
+          return Response.json(handleListGroups(body as ListGroupsRequest));
+        case "/send-group-message":
+          return Response.json(handleSendGroupMessage(body as SendGroupMessageRequest));
         default:
           return Response.json({ error: "not found" }, { status: 404 });
       }

--- a/server.ts
+++ b/server.ts
@@ -25,6 +25,8 @@ import type {
   RegisterResponse,
   PollMessagesResponse,
   Message,
+  Group,
+  GroupMember,
 } from "./shared/types.ts";
 import {
   generateSummary,
@@ -156,9 +158,16 @@ Read the from_id, from_summary, and from_cwd attributes to understand who sent t
 
 Available tools:
 - list_peers: Discover other Claude Code instances (scope: machine/directory/repo)
-- send_message: Send a message to another instance by ID
+- send_message: Send a message to another instance by ID (unicast)
 - set_summary: Set a 1-2 sentence summary of what you're working on (visible to other peers)
 - check_messages: Manually check for new messages
+- create_group: Create a named group for multicast messaging
+- join_group: Join a group (persists across sessions via your working directory)
+- leave_group: Leave a group
+- list_groups: List groups and their members
+- send_group_message: Send a message to all active members of a group (multicast)
+
+When you receive a group message, the channel notification will include a group_name attribute. To reply to the whole group, use send_group_message with that group name rather than send_message to the individual sender.
 
 When you start, proactively call set_summary to describe what you're working on. This helps other instances understand your context.`,
   }
@@ -225,6 +234,87 @@ const TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {},
+    },
+  },
+  {
+    name: "create_group",
+    description:
+      "Create a named group for multicast messaging. Any peer can then join with join_group. Group names are unique and persist across sessions.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string" as const,
+          description: 'A short, unique name for the group (e.g. "family", "cpus", "project-x")',
+        },
+        description: {
+          type: "string" as const,
+          description: "Optional description of the group's purpose",
+        },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "join_group",
+    description:
+      "Join a group. Membership is tied to your working directory, so it persists across sessions automatically. You will receive messages sent to this group via send_group_message.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        group_name: {
+          type: "string" as const,
+          description: "The name of the group to join",
+        },
+      },
+      required: ["group_name"],
+    },
+  },
+  {
+    name: "leave_group",
+    description: "Leave a group. You will no longer receive messages sent to this group.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        group_name: {
+          type: "string" as const,
+          description: "The name of the group to leave",
+        },
+      },
+      required: ["group_name"],
+    },
+  },
+  {
+    name: "list_groups",
+    description:
+      "List groups and their members. By default lists only groups you belong to. Set all to true to see every group.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        all: {
+          type: "boolean" as const,
+          description: "If true, list all groups on the broker, not just your own",
+        },
+      },
+    },
+  },
+  {
+    name: "send_group_message",
+    description:
+      "Send a message to all active members of a group (multicast). The message is delivered to every online group member except yourself.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        group_name: {
+          type: "string" as const,
+          description: "The name of the group to send to",
+        },
+        message: {
+          type: "string" as const,
+          description: "The message to send",
+        },
+      },
+      required: ["group_name", "message"],
     },
   },
 ];
@@ -394,6 +484,147 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       }
     }
 
+    case "create_group": {
+      const { name: groupName, description } = args as { name: string; description?: string };
+      try {
+        const result = await brokerFetch<{ ok: boolean; error?: string }>("/create-group", {
+          name: groupName,
+          description,
+        });
+        if (!result.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to create group: ${result.error}` }],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text" as const, text: `Group '${groupName}' created.` }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Error creating group: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    }
+
+    case "join_group": {
+      const { group_name } = args as { group_name: string };
+      if (!myId) {
+        return {
+          content: [{ type: "text" as const, text: "Not registered with broker yet" }],
+          isError: true,
+        };
+      }
+      try {
+        const result = await brokerFetch<{ ok: boolean; error?: string }>("/join-group", {
+          group_name,
+          peer_id: myId,
+          member_cwd: myCwd,
+        });
+        if (!result.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to join group: ${result.error}` }],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text" as const, text: `Joined group '${group_name}'.` }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Error joining group: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    }
+
+    case "leave_group": {
+      const { group_name } = args as { group_name: string };
+      try {
+        const result = await brokerFetch<{ ok: boolean; error?: string }>("/leave-group", {
+          group_name,
+          member_cwd: myCwd,
+        });
+        if (!result.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to leave group: ${result.error}` }],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text" as const, text: `Left group '${group_name}'.` }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Error leaving group: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    }
+
+    case "list_groups": {
+      const { all } = (args ?? {}) as { all?: boolean };
+      try {
+        const result = await brokerFetch<{ groups: (Group & { members: GroupMember[] })[] }>(
+          "/list-groups",
+          all ? {} : { member_cwd: myCwd }
+        );
+
+        if (result.groups.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: all ? "No groups exist yet." : "You are not in any groups." }],
+          };
+        }
+
+        const lines = result.groups.map((g) => {
+          const memberList = g.members
+            .map((m) => `    ${m.member_cwd} ${m.active_peer_id ? `(online: ${m.active_peer_id})` : "(offline)"}`)
+            .join("\n");
+          return `Group: ${g.name}${g.description ? ` — ${g.description}` : ""}\n  Created: ${g.created_at}\n  Members:\n${memberList}`;
+        });
+
+        return {
+          content: [{ type: "text" as const, text: lines.join("\n\n") }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Error listing groups: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    }
+
+    case "send_group_message": {
+      const { group_name, message } = args as { group_name: string; message: string };
+      if (!myId) {
+        return {
+          content: [{ type: "text" as const, text: "Not registered with broker yet" }],
+          isError: true,
+        };
+      }
+      try {
+        const result = await brokerFetch<{ ok: boolean; error?: string; sent_to: number }>(
+          "/send-group-message",
+          { from_id: myId, group_name, text: message }
+        );
+        if (!result.ok) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to send to group: ${result.error}` }],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text" as const, text: `Message sent to group '${group_name}' (${result.sent_to} recipient(s)).` }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Error sending group message: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    }
+
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
@@ -427,20 +658,25 @@ async function pollAndPushMessages() {
       }
 
       // Push as channel notification — this is what makes it immediate
+      const meta: Record<string, string> = {
+        from_id: msg.from_id,
+        from_summary: fromSummary,
+        from_cwd: fromCwd,
+        sent_at: msg.sent_at,
+      };
+      if (msg.group_name) {
+        meta.group_name = msg.group_name;
+      }
+
       await mcp.notification({
         method: "notifications/claude/channel",
         params: {
           content: msg.text,
-          meta: {
-            from_id: msg.from_id,
-            from_summary: fromSummary,
-            from_cwd: fromCwd,
-            sent_at: msg.sent_at,
-          },
+          meta,
         },
       });
 
-      log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+      log(`Pushed message from ${msg.from_id}${msg.group_name ? ` (group: ${msg.group_name})` : ""}: ${msg.text.slice(0, 80)}`);
     }
   } catch (e) {
     // Broker might be down temporarily, don't crash

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -19,6 +19,22 @@ export interface Message {
   text: string;
   sent_at: string; // ISO timestamp
   delivered: boolean;
+  group_name: string | null; // non-null if this message originated from a group send
+}
+
+// --- Group / multicast types ---
+
+export interface Group {
+  name: string;
+  description: string;
+  created_at: string; // ISO timestamp
+}
+
+export interface GroupMember {
+  group_name: string;
+  member_cwd: string;
+  active_peer_id: PeerId | null; // current session's peer ID, null if offline
+  joined_at: string; // ISO timestamp
 }
 
 // --- Broker API types ---
@@ -64,4 +80,32 @@ export interface PollMessagesRequest {
 
 export interface PollMessagesResponse {
   messages: Message[];
+}
+
+// --- Group broker API types ---
+
+export interface CreateGroupRequest {
+  name: string;
+  description?: string;
+}
+
+export interface JoinGroupRequest {
+  group_name: string;
+  peer_id: PeerId;
+  member_cwd: string;
+}
+
+export interface LeaveGroupRequest {
+  group_name: string;
+  member_cwd: string;
+}
+
+export interface ListGroupsRequest {
+  member_cwd?: string; // if provided, only return groups this CWD belongs to
+}
+
+export interface SendGroupMessageRequest {
+  from_id: PeerId;
+  group_name: string;
+  text: string;
 }


### PR DESCRIPTION
## Summary

Adds named groups for multicast messaging, extending the existing unicast system:

- **5 new MCP tools:** `create_group`, `join_group`, `leave_group`, `list_groups`, `send_group_message`
- **5 new broker endpoints:** `/create-group`, `/join-group`, `/leave-group`, `/list-groups`, `/send-group-message`
- **2 new database tables:** `groups` and `group_members`
- **CWD-based persistent membership** — group membership is keyed by working directory, not ephemeral peer ID, so it survives session restarts automatically
- **Fan-out at the broker** — `send_group_message` creates one unicast message per active group member in the existing `messages` table. Zero changes to the delivery pipeline (polling + channel push works unchanged)
- **Sender exclusion** — you don't receive your own group messages
- **`group_name` in notification metadata** — recipients know a message came from a group and can reply with `send_group_message` instead of unicasting back
- **Backward compatible** — existing unicast tools and endpoints work identically. The `group_name` column on `messages` is nullable with an `ALTER TABLE` migration for existing databases

## Motivation

With multiple Claude Code instances running as a team, unicast messaging creates a bottleneck: if peer A sends to peer B, peer C can't see it. This causes communication stalls where peers unknowingly wait for information relayed through a third party. Groups solve this by letting peers broadcast to all members at once.

## Design decisions

- **CWD as stable identity:** Peer IDs are regenerated every session, but working directories are stable. Groups reference CWDs, and the broker auto-links new peer IDs to existing memberships on registration.
- **Fan-out into existing unicast:** Rather than adding a separate multicast delivery path, group messages become N individual rows in the `messages` table. This reuses the entire polling and channel push infrastructure with zero changes.
- **Quadratic explosion awareness:** The README documents the N×(N-1) cost of group replies and recommends unicast-first usage patterns.

## Test plan

- [x] TypeScript compiles with zero errors (`bunx tsc --noEmit`)
- [x] Broker starts cleanly with fresh database (new tables created)
- [x] Broker starts cleanly with existing database (`ALTER TABLE` migration)
- [x] Create group, join group, list groups — verified via curl
- [x] Send group message — fan-out creates correct number of unicast messages
- [x] Sender excluded from own group messages
- [x] Duplicate group creation rejected
- [x] Auto-join on re-registration (simulated compaction: unregister + register with same CWD, new peer ID)
- [x] Channel notifications include `group_name` metadata for group messages
- [x] Existing unicast tools work unchanged

Brian Bushnell, Noire