### PR TITLE
fix(server): resolve broker script path correctly on Windows

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -13,6 +13,7 @@
  *   { "claude-peers": { "command": "bun", "args": ["./server.ts"] } }
  */
 
+import { fileURLToPath } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -38,7 +39,7 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const BROKER_SCRIPT = fileURLToPath(new URL("./broker.ts", import.meta.url));
 
 // --- Broker communication ---
 


### PR DESCRIPTION
## Summary

`server.ts:41` uses `new URL("./broker.ts", import.meta.url).pathname` to derive the broker script path. On Windows, the WHATWG URL spec formats file URLs with a leading slash (e.g. `/C:/Users/.../broker.ts`), which `Bun.spawn` rejects:

```
error: Module not found "/C:/Users/gabri/claude-peers-mcp/broker.ts"
```

Result: `claude mcp list` shows `claude-peers: ✗ Failed to connect` on Windows, and the broker never auto-launches.

## Fix

Use `fileURLToPath` from `node:url`, which normalizes the path correctly on both platforms:

- **Windows**: `C:\Users\...\broker.ts`
- **POSIX**: `/Users/.../broker.ts`

2-line change (1 new import, 1 line modified).

## Verification (Windows 11, Bun 1.3.11, Claude Code 2.1.96)

**Before:**
```bash
$ claude mcp list | grep claude-peers
claude-peers: C:/Users/gabri/.bun/bin/bun.exe C:/Users/gabri/claude-peers-mcp/server.ts - ✗ Failed to connect
```

**After:**
```bash
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | bun server.ts
[claude-peers] Starting broker daemon...
[claude-peers broker] listening on 127.0.0.1:7899 (db: C:\Users\gabri/.claude-peers.db)
[claude-peers] Broker started
[claude-peers] CWD: C:\Users\gabri\claude-peers-mcp
[claude-peers] Registered as peer queeuxou
[claude-peers] MCP connected
{"result":{"protocolVersion":"2024-11-05","capabilities":{...},"serverInfo":{"name":"claude-peers","version":"0.1.0"},...}

$ claude mcp list | grep claude-peers
claude-peers: bun ./server.ts - ✓ Connected
```

## Known residual Windows issue (not addressed in this PR)

The broker process is spawned without `detached: true` (line ~74). On POSIX, `proc.unref()` is enough to keep it alive when the parent server exits. On Windows, the child inherits the process group and gets killed when the parent dies. This means the broker restarts on every new session instead of surviving across them.

Mitigation is already built in: every new `server.ts` instance calls `ensureBroker()` which respawns if dead. So this doesn't break functionality — it just means no cross-session persistence on Windows. Happy to send a follow-up PR with a proper Windows detach path if that's desirable.

## Test plan

- [x] Handshake test (`echo initialize | bun server.ts`) returns valid MCP response
- [x] `claude mcp list` reports `✓ Connected` on Windows
- [x] Broker auto-launches on first registration
- [ ] POSIX regression test — no POSIX machine handy; `fileURLToPath` is a standard API and round-trips the same URL format, so behavior should be identical