### PR TITLE
Multi-tenant desktop session support for Cowork

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -19,6 +19,7 @@ import type {
   SendMessageRequest,
   PollMessagesRequest,
   PollMessagesResponse,
+  AckMessagesRequest,
   Peer,
   Message,
 } from "./shared/types.ts";
@@ -40,6 +41,7 @@ db.run(`
     git_root TEXT,
     tty TEXT,
     summary TEXT NOT NULL DEFAULT '',
+    peer_type TEXT NOT NULL DEFAULT 'cli',
     registered_at TEXT NOT NULL,
     last_seen TEXT NOT NULL
   )
@@ -58,9 +60,18 @@ db.run(`
   )
 `);
 
+// Cache summaries by workspace so they survive across sessions
+db.run(`
+  CREATE TABLE IF NOT EXISTS summary_cache (
+    key TEXT PRIMARY KEY,
+    summary TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )
+`);
+
 // Clean up stale peers (PIDs that no longer exist) on startup
 function cleanStalePeers() {
-  const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
+  const peers = db.query("SELECT id, pid, peer_type FROM peers").all() as { id: string; pid: number; peer_type: string }[];
   for (const peer of peers) {
     try {
       // Check if process is still alive (signal 0 doesn't kill, just checks)
@@ -71,9 +82,21 @@ function cleanStalePeers() {
       db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
     }
   }
+
+  // Clean stale desktop peers by heartbeat timeout (PID check doesn't work — shared VM)
+  const staleTimeout = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  db.run("DELETE FROM messages WHERE delivered = 0 AND to_id IN (SELECT id FROM peers WHERE peer_type = 'desktop' AND last_seen < ?)", [staleTimeout]);
+  db.run("DELETE FROM peers WHERE peer_type = 'desktop' AND last_seen < ?", [staleTimeout]);
+
+  // TTL: delivered messages > 24h, summary cache > 7d
+  db.run("DELETE FROM messages WHERE delivered = 1 AND sent_at < ?", [new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()]);
+  db.run("DELETE FROM summary_cache WHERE updated_at < ?", [new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()]);
 }
 
 cleanStalePeers();
+
+// Reclaim disk space after initial cleanup
+db.run("VACUUM");
 
 // Periodically clean stale peers (every 30s)
 setInterval(cleanStalePeers, 30_000);
@@ -81,8 +104,8 @@ setInterval(cleanStalePeers, 30_000);
 // --- Prepared statements ---
 
 const insertPeer = db.prepare(`
-  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, registered_at, last_seen)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, peer_type, registered_at, last_seen)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateLastSeen = db.prepare(`
@@ -118,6 +141,19 @@ const selectUndelivered = db.prepare(`
   SELECT * FROM messages WHERE to_id = ? AND delivered = 0 ORDER BY sent_at ASC
 `);
 
+const selectUndeliveredSince = db.prepare(`
+  SELECT * FROM messages WHERE to_id = ? AND delivered = 0 AND id > ? ORDER BY sent_at ASC
+`);
+
+const upsertSummaryCache = db.prepare(`
+  INSERT INTO summary_cache (key, summary, updated_at) VALUES (?, ?, ?)
+  ON CONFLICT(key) DO UPDATE SET summary = excluded.summary, updated_at = excluded.updated_at
+`);
+
+const selectSummaryCache = db.prepare(`
+  SELECT summary FROM summary_cache WHERE key = ?
+`);
+
 const markDelivered = db.prepare(`
   UPDATE messages SET delivered = 1 WHERE id = ?
 `);
@@ -133,28 +169,73 @@ function generateId(): string {
   return id;
 }
 
+// --- Summary cache helpers ---
+
+function summaryCacheKey(cwd: string, git_root: string | null): string {
+  return git_root ?? cwd;
+}
+
+function cacheSummary(cwd: string, git_root: string | null, summary: string): void {
+  if (!summary) return;
+  const key = summaryCacheKey(cwd, git_root);
+  upsertSummaryCache.run(key, summary, new Date().toISOString());
+}
+
+function getCachedSummary(cwd: string, git_root: string | null): string | null {
+  const key = summaryCacheKey(cwd, git_root);
+  const row = selectSummaryCache.get(key) as { summary: string } | null;
+  return row?.summary ?? null;
+}
+
 // --- Request handlers ---
 
 function handleRegister(body: RegisterRequest): RegisterResponse {
   const id = generateId();
   const now = new Date().toISOString();
 
-  // Remove any existing registration for this PID (re-registration)
-  const existing = db.query("SELECT id FROM peers WHERE pid = ?").get(body.pid) as { id: string } | null;
-  if (existing) {
-    deletePeer.run(existing.id);
+  const peerType = body.peer_type ?? "cli";
+  const isCli = peerType !== "desktop";
+
+  // Remove any existing registration for this PID (re-registration).
+  // Desktop sessions share one VM PID, so PID-based dedup would delete other active sessions.
+  if (isCli) {
+    const existing = db.query("SELECT id FROM peers WHERE pid = ?").get(body.pid) as { id: string } | null;
+    if (existing) {
+      deletePeer.run(existing.id);
+    }
   }
 
-  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now);
-  return { id };
+  // Carry forward cached summary for CLI sessions in the same workspace.
+  // Desktop sessions always set fresh summaries and would collide on one cache slot.
+  let summary = body.summary;
+  if (!summary && isCli) {
+    summary = getCachedSummary(body.cwd, body.git_root) ?? "";
+  }
+
+  if (summary && isCli) {
+    cacheSummary(body.cwd, body.git_root, summary);
+  }
+
+  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, summary, peerType, now, now);
+  return { id, restored_summary: summary !== body.summary ? summary : undefined };
 }
 
 function handleHeartbeat(body: HeartbeatRequest): void {
   updateLastSeen.run(new Date().toISOString(), body.id);
 }
 
-function handleSetSummary(body: SetSummaryRequest): void {
+function handleSetSummary(body: SetSummaryRequest): { ok: boolean; error?: string } {
+  const peer = db.query("SELECT id, cwd, git_root, peer_type FROM peers WHERE id = ?").get(body.id) as { id: string; cwd: string; git_root: string | null; peer_type: string } | null;
+  if (!peer) {
+    return { ok: false, error: `Peer ${body.id} not found — re-register via /register` };
+  }
   updateSummary.run(body.summary, body.id);
+  // Persist to cache so future CLI sessions in this workspace inherit it.
+  // Desktop sessions are excluded — they set fresh summaries and would collide in shared workspaces.
+  if (peer.peer_type !== "desktop") {
+    cacheSummary(peer.cwd, peer.git_root, body.summary);
+  }
+  return { ok: true };
 }
 
 function handleListPeers(body: ListPeersRequest): Peer[] {
@@ -184,13 +265,14 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
     peers = peers.filter((p) => p.id !== body.exclude_id);
   }
 
-  // Verify each peer's process is still alive
+  // Verify each peer's process is still alive.
+  // Desktop peers share one VM PID — skip the kill check; heartbeat timeout handles staleness.
   return peers.filter((p) => {
+    if (p.peer_type === "desktop") return true;
     try {
       process.kill(p.pid, 0);
       return true;
     } catch {
-      // Clean up dead peer
       deletePeer.run(p.id);
       return false;
     }
@@ -210,12 +292,23 @@ function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: str
 
 function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
   const messages = selectUndelivered.all(body.id) as Message[];
+  // Don't mark as delivered here — let the caller ack explicitly
+  // so messages aren't lost when channel push silently fails.
+  return { messages };
+}
 
-  // Mark them as delivered
-  for (const msg of messages) {
-    markDelivered.run(msg.id);
-  }
+function handleAckMessages(body: AckMessagesRequest): void {
+  db.transaction(() => {
+    for (const id of body.message_ids) {
+      markDelivered.run(id);
+    }
+  })();
+}
 
+function handlePeekMessages(body: { id: string; since_id?: number }): PollMessagesResponse {
+  const sinceId = body.since_id ?? 0;
+  const messages = selectUndeliveredSince.all(body.id, sinceId) as Message[];
+  // Don't mark as delivered — just peek
   return { messages };
 }
 
@@ -248,15 +341,24 @@ Bun.serve({
         case "/heartbeat":
           handleHeartbeat(body as HeartbeatRequest);
           return Response.json({ ok: true });
-        case "/set-summary":
-          handleSetSummary(body as SetSummaryRequest);
-          return Response.json({ ok: true });
+        case "/set-summary": {
+          const summaryResult = handleSetSummary(body as SetSummaryRequest);
+          if (!summaryResult.ok) {
+            return Response.json(summaryResult, { status: 404 });
+          }
+          return Response.json(summaryResult);
+        }
         case "/list-peers":
           return Response.json(handleListPeers(body as ListPeersRequest));
         case "/send-message":
           return Response.json(handleSendMessage(body as SendMessageRequest));
         case "/poll-messages":
           return Response.json(handlePollMessages(body as PollMessagesRequest));
+        case "/ack-messages":
+          handleAckMessages(body as AckMessagesRequest);
+          return Response.json({ ok: true });
+        case "/peek-messages":
+          return Response.json(handlePeekMessages(body as { id: string; since_id?: number }));
         case "/unregister":
           handleUnregister(body as { id: string });
           return Response.json({ ok: true });

--- a/server.ts
+++ b/server.ts
@@ -39,6 +39,23 @@ const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const PEER_NAME = process.env.CLAUDE_PEERS_NAME ?? "";
+
+// Detect if running inside Claude Desktop (launched via disclaimer wrapper)
+function detectPeerType(): "cli" | "desktop" {
+  try {
+    const ppid = process.ppid;
+    if (ppid) {
+      const proc = Bun.spawnSync(["ps", "-p", String(ppid), "-o", "command="]);
+      const cmd = new TextDecoder().decode(proc.stdout).trim();
+      if (cmd.includes("Claude.app") || cmd.includes("disclaimer")) {
+        return "desktop";
+      }
+    }
+  } catch { /* default to cli */ }
+  return "cli";
+}
+const PEER_TYPE = detectPeerType();
 
 // --- Broker communication ---
 
@@ -98,6 +115,33 @@ function log(msg: string) {
   console.error(`[claude-peers] ${msg}`);
 }
 
+async function ensureRegistered(): Promise<void> {
+  // Re-register if our peer was cleaned up by the broker
+  if (!myId) return;
+  try {
+    const peers = await brokerFetch<Peer[]>("/list-peers", {
+      scope: "machine",
+      cwd: myCwd,
+      git_root: myGitRoot,
+    });
+    if (!peers.some((p) => p.id === myId)) {
+      const tty = getTty();
+      const reg = await brokerFetch<RegisterResponse>("/register", {
+        pid: process.pid,
+        cwd: myCwd,
+        git_root: myGitRoot,
+        tty,
+        summary: myLastSummary || PEER_NAME,
+        peer_type: PEER_TYPE,
+      });
+      log(`Re-registered as peer ${reg.id} (was ${myId})`);
+      myId = reg.id;
+    }
+  } catch {
+    // Non-critical
+  }
+}
+
 async function getGitRoot(cwd: string): Promise<string | null> {
   try {
     const proc = Bun.spawn(["git", "rev-parse", "--show-toplevel"], {
@@ -138,6 +182,29 @@ function getTty(): string | null {
 let myId: PeerId | null = null;
 let myCwd = process.cwd();
 let myGitRoot: string | null = null;
+let myLastSummary: string = ""; // Track the most recent summary for re-registration
+let hasSamplingSupport = false; // Whether the client supports sampling (createMessage)
+
+// For desktop (Cowork), multiple sessions share this server process.
+// Each session registers as a separate peer, keyed by session_id.
+const desktopPeers = new Map<string, { peerId: PeerId; summary: string }>();
+
+async function getDesktopPeerId(sessionId: string): Promise<PeerId> {
+  const existing = desktopPeers.get(sessionId);
+  if (existing) return existing.peerId;
+
+  // Register a new peer for this desktop session
+  const reg = await brokerFetch<RegisterResponse>("/register", {
+    pid: process.pid,
+    cwd: sessionId, // Use session sandbox path as CWD — distinguishes sessions
+    git_root: null,
+    tty: null,
+    summary: "",
+    peer_type: "desktop",
+  });
+  desktopPeers.set(sessionId, { peerId: reg.id, summary: "" });
+  return reg.id;
+}
 
 // --- MCP Server ---
 
@@ -147,6 +214,7 @@ const mcp = new Server(
     capabilities: {
       experimental: { "claude/channel": {} },
       tools: {},
+      logging: {},
     },
     instructions: `You are connected to the claude-peers network. Other Claude Code instances on this machine can see you and send you messages.
 
@@ -155,12 +223,22 @@ IMPORTANT: When you receive a <channel source="claude-peers" ...> message, RESPO
 Read the from_id, from_summary, and from_cwd attributes to understand who sent the message. Reply by calling send_message with their from_id.
 
 Available tools:
-- list_peers: Discover other Claude Code instances (scope: machine/directory/repo)
-- send_message: Send a message to another instance by ID
+- list_peers: Discover other Claude Code instances (scope: machine/directory/repo). Shows YOUR peer ID and all other peers with their IDs and summaries.
+- send_message: Send a message to another instance by peer ID
 - set_summary: Set a 1-2 sentence summary of what you're working on (visible to other peers)
-- check_messages: Manually check for new messages
+- check_messages: Manually check for new messages (call this periodically if you're expecting replies)
 
-When you start, proactively call set_summary to describe what you're working on. This helps other instances understand your context.`,
+CRITICAL FIRST STEPS — do these immediately when you start:
+1. Call set_summary with your role/name and what you're working on (e.g. "Design agent. Reviewing clinician UX mockups.")
+2. Call list_peers with scope "machine" to see who else is online and learn your own peer ID.
+
+Use summaries to identify peers — peer IDs change on restart, but summaries tell you who's who.
+
+MESSAGING ROUTING — each peer has a Type (cli or desktop) shown in list_peers:
+- To message a "cli" peer: use send_message (they receive it instantly via channel push)
+- To message a "desktop" peer: use send_message (they receive it on their next tool call). If you are ALSO a desktop session and have access to dispatch:send_message, prefer that — it wakes idle sessions immediately.
+- To message another desktop session from desktop: use dispatch:send_message with their session ID (from session_info:list_sessions) for instant delivery.` +
+      (PEER_NAME ? `\n\nYour assigned identity is: "${PEER_NAME}". Always include this name when setting your summary. This is who you are on the network — do not adopt a different identity even if other peers' summaries seem to conflict.` : ""),
   }
 );
 
@@ -179,6 +257,11 @@ const TOOLS = [
           enum: ["machine", "directory", "repo"],
           description:
             'Scope of peer discovery. "machine" = all instances on this computer. "directory" = same working directory. "repo" = same git repository (including worktrees or subdirectories).',
+        },
+        session_id: {
+          type: "string" as const,
+          description:
+            "Optional. Cowork session identifier (sandbox CWD). Desktop sessions pass this to maintain independent peer identities.",
         },
       },
       required: ["scope"],
@@ -199,6 +282,11 @@ const TOOLS = [
           type: "string" as const,
           description: "The message to send",
         },
+        session_id: {
+          type: "string" as const,
+          description:
+            "Optional. Cowork session identifier (sandbox CWD). Desktop sessions pass this to maintain independent peer identities.",
+        },
       },
       required: ["to_id", "message"],
     },
@@ -214,6 +302,11 @@ const TOOLS = [
           type: "string" as const,
           description: "A 1-2 sentence summary of your current work",
         },
+        session_id: {
+          type: "string" as const,
+          description:
+            "Optional. Cowork session identifier (sandbox CWD). Desktop sessions pass this to maintain independent peer identities.",
+        },
       },
       required: ["summary"],
     },
@@ -224,20 +317,51 @@ const TOOLS = [
       "Manually check for new messages from other Claude Code instances. Messages are normally pushed automatically via channel notifications, but you can use this as a fallback.",
     inputSchema: {
       type: "object" as const,
-      properties: {},
+      properties: {
+        session_id: {
+          type: "string" as const,
+          description:
+            "Optional. Cowork session identifier (sandbox CWD). Desktop sessions pass this to maintain independent peer identities.",
+        },
+      },
     },
   },
 ];
 
 // --- Tool handlers ---
 
-mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: TOOLS,
-}));
+// Track pending message previews for dynamic tool descriptions
+let pendingMessagePreview = "";
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => {
+  if (!pendingMessagePreview) return { tools: TOOLS };
+
+  // Inject message preview into check_messages description
+  const dynamicTools = TOOLS.map((t) => {
+    if (t.name === "check_messages") {
+      return {
+        ...t,
+        description: `⚠️ NEW MESSAGES WAITING — CALL THIS TOOL NOW.\n\nPreview: ${pendingMessagePreview}\n\n${t.description}`,
+      };
+    }
+    return t;
+  });
+  return { tools: dynamicTools };
+});
 
 mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  log(`Tool call raw request: ${JSON.stringify(req.params)}`);
   const { name, arguments: args } = req.params;
+  const sessionId = args?.session_id as string | undefined;
+  const effectivePeerId =
+    sessionId && PEER_TYPE === "desktop"
+      ? await getDesktopPeerId(sessionId)
+      : myId;
+  const toolResult = await handleTool(name, args, effectivePeerId, sessionId);
+  return appendPendingMessages(toolResult, name, effectivePeerId);
+});
 
+async function handleTool(name: string, args: Record<string, unknown> | undefined, effectivePeerId: PeerId | null, sessionId: string | undefined): Promise<any> {
   switch (name) {
     case "list_peers": {
       const scope = (args as { scope: string }).scope as "machine" | "directory" | "repo";
@@ -246,15 +370,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           scope,
           cwd: myCwd,
           git_root: myGitRoot,
-          exclude_id: myId,
+          exclude_id: effectivePeerId,
         });
+
+        const header = `Your peer ID: ${effectivePeerId}\n\n`;
 
         if (peers.length === 0) {
           return {
             content: [
               {
                 type: "text" as const,
-                text: `No other Claude Code instances found (scope: ${scope}).`,
+                text: `${header}No other Claude Code instances found (scope: ${scope}).`,
               },
             ],
           };
@@ -263,6 +389,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         const lines = peers.map((p) => {
           const parts = [
             `ID: ${p.id}`,
+            `Type: ${p.peer_type ?? "cli"}`,
             `PID: ${p.pid}`,
             `CWD: ${p.cwd}`,
           ];
@@ -277,7 +404,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           content: [
             {
               type: "text" as const,
-              text: `Found ${peers.length} peer(s) (scope: ${scope}):\n\n${lines.join("\n\n")}`,
+              text: `${header}Found ${peers.length} peer(s) (scope: ${scope}):\n\n${lines.join("\n\n")}`,
             },
           ],
         };
@@ -296,7 +423,13 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 
     case "send_message": {
       const { to_id, message } = args as { to_id: string; message: string };
-      if (!myId) {
+      if (!to_id) {
+        return {
+          content: [{ type: "text" as const, text: "Missing to_id. Call list_peers first to get peer IDs, then pass the ID as to_id." }],
+          isError: true,
+        };
+      }
+      if (!effectivePeerId) {
         return {
           content: [{ type: "text" as const, text: "Not registered with broker yet" }],
           isError: true,
@@ -304,7 +437,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
       }
       try {
         const result = await brokerFetch<{ ok: boolean; error?: string }>("/send-message", {
-          from_id: myId,
+          from_id: effectivePeerId,
           to_id,
           text: message,
         });
@@ -332,23 +465,70 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
 
     case "set_summary": {
       const { summary } = args as { summary: string };
-      if (!myId) {
+      if (!effectivePeerId) {
         return {
           content: [{ type: "text" as const, text: "Not registered with broker yet" }],
           isError: true,
         };
       }
       try {
-        await brokerFetch("/set-summary", { id: myId, summary });
+        await brokerFetch("/set-summary", { id: effectivePeerId, summary });
+        // Update the right summary store
+        if (sessionId && PEER_TYPE === "desktop") {
+          const entry = desktopPeers.get(sessionId);
+          if (entry) entry.summary = summary;
+        } else {
+          myLastSummary = summary;
+        }
         return {
-          content: [{ type: "text" as const, text: `Summary updated: "${summary}"` }],
+          content: [{ type: "text" as const, text: `Summary updated: "${summary}" (your peer ID: ${effectivePeerId})` }],
         };
       } catch (e) {
+        // If peer was cleaned up, re-register
+        const errMsg = e instanceof Error ? e.message : String(e);
+        if (errMsg.includes("not found")) {
+          try {
+            if (sessionId && PEER_TYPE === "desktop") {
+              // Re-register with summary in one call (avoids extra /set-summary round-trip)
+              desktopPeers.delete(sessionId);
+              const reg = await brokerFetch<RegisterResponse>("/register", {
+                pid: process.pid,
+                cwd: sessionId,
+                git_root: null,
+                tty: null,
+                summary,
+                peer_type: "desktop",
+              });
+              desktopPeers.set(sessionId, { peerId: reg.id, summary });
+              log(`Re-registered desktop session ${sessionId} as peer ${reg.id}`);
+              return {
+                content: [{ type: "text" as const, text: `Re-registered and summary set: "${summary}" (new peer ID: ${reg.id})` }],
+              };
+            } else {
+              const tty = getTty();
+              const reg = await brokerFetch<RegisterResponse>("/register", {
+                pid: process.pid,
+                cwd: myCwd,
+                git_root: myGitRoot,
+                tty,
+                summary,
+              });
+              myId = reg.id;
+              myLastSummary = summary;
+              log(`Re-registered as peer ${myId} after stale cleanup`);
+              return {
+                content: [{ type: "text" as const, text: `Re-registered and summary set: "${summary}" (new peer ID: ${myId})` }],
+              };
+            }
+          } catch (regErr) {
+            // fall through to error
+          }
+        }
         return {
           content: [
             {
               type: "text" as const,
-              text: `Error setting summary: ${e instanceof Error ? e.message : String(e)}`,
+              text: `Error setting summary: ${errMsg}`,
             },
           ],
           isError: true,
@@ -357,14 +537,23 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     }
 
     case "check_messages": {
-      if (!myId) {
+      if (!effectivePeerId) {
         return {
           content: [{ type: "text" as const, text: "Not registered with broker yet" }],
           isError: true,
         };
       }
       try {
-        const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+        const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: effectivePeerId });
+        if (result.messages.length > 0) {
+          await ackMessages(result.messages);
+        }
+        if (pendingMessagePreview) {
+          pendingMessagePreview = "";
+          try {
+            await mcp.notification({ method: "notifications/tools/list_changed" });
+          } catch { /* non-critical */ }
+        }
         if (result.messages.length === 0) {
           return {
             content: [{ type: "text" as const, text: "No new messages." }],
@@ -397,55 +586,185 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
-});
+}
+
+// --- Piggyback message delivery on every tool call ---
+// Appends pending messages to any tool response so Desktop sessions
+// get messages opportunistically without calling check_messages.
+
+async function appendPendingMessages(result: { content: { type: string; text: string }[] }, toolName: string, effectivePeerId: PeerId | null) {
+  if (!effectivePeerId || toolName === "check_messages" || !pendingMessagePreview) return result;
+  try {
+    const pending = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: effectivePeerId });
+    if (pending.messages.length > 0) {
+      await ackMessages(pending.messages);
+      const inbox = pending.messages
+        .map((m) => `From ${m.from_id} (${m.sent_at}):\n${m.text}`)
+        .join("\n\n---\n\n");
+      result.content.push({
+        type: "text" as const,
+        text: `\n\n📨 ${pending.messages.length} new message(s) arrived:\n\n${inbox}`,
+      });
+    }
+  } catch {
+    // Non-critical
+  }
+  return result;
+}
+
+// --- Message ack helper ---
+
+let lastSeenMessageId = 0;
+// Track message IDs already pushed via channel to avoid re-pushing every poll cycle.
+// Messages are NOT acked by the poll loop — only check_messages/piggybacking acks them —
+// so they remain available as a fallback when channels aren't active.
+const pushedMessageIds = new Set<number>();
+
+async function ackMessages(messages: Message[]): Promise<void> {
+  const ids = messages.map((m) => m.id);
+  await brokerFetch("/ack-messages", { message_ids: ids });
+  for (const id of ids) {
+    pushedMessageIds.add(id);
+    if (id > lastSeenMessageId) lastSeenMessageId = id;
+  }
+  // Prune old entries — only IDs near the high-water mark matter
+  if (pushedMessageIds.size > 1000) {
+    const threshold = lastSeenMessageId - 500;
+    for (const id of pushedMessageIds) {
+      if (id < threshold) pushedMessageIds.delete(id);
+    }
+  }
+}
 
 // --- Polling loop for inbound messages ---
 
-async function pollAndPushMessages() {
-  if (!myId) return;
-
+async function pollForPeer(peerId: PeerId) {
   try {
-    const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+    const result = await brokerFetch<PollMessagesResponse>("/peek-messages", {
+      id: peerId,
+      since_id: lastSeenMessageId,
+    });
 
-    for (const msg of result.messages) {
-      // Look up the sender's info for context
-      let fromSummary = "";
-      let fromCwd = "";
+    // Fetch peer list once for sender lookups (not per-message)
+    let peersCache: Peer[] | null = null;
+    if (result.messages.some((m) => !pushedMessageIds.has(m.id))) {
       try {
-        const peers = await brokerFetch<Peer[]>("/list-peers", {
+        peersCache = await brokerFetch<Peer[]>("/list-peers", {
           scope: "machine",
           cwd: myCwd,
           git_root: myGitRoot,
         });
-        const sender = peers.find((p) => p.id === msg.from_id);
-        if (sender) {
-          fromSummary = sender.summary;
-          fromCwd = sender.cwd;
-        }
       } catch {
         // Non-critical, proceed without sender info
       }
+    }
 
-      // Push as channel notification — this is what makes it immediate
-      await mcp.notification({
-        method: "notifications/claude/channel",
-        params: {
-          content: msg.text,
-          meta: {
+    for (const msg of result.messages) {
+      if (pushedMessageIds.has(msg.id)) continue;
+
+      if (msg.id > lastSeenMessageId) {
+        lastSeenMessageId = msg.id;
+      }
+      const sender = peersCache?.find((p) => p.id === msg.from_id);
+      const fromSummary = sender?.summary ?? "";
+      const fromCwd = sender?.cwd ?? "";
+
+      // Try ALL delivery mechanisms — none are confirmed delivery, so fire all of them
+
+      // 1. Channel notification (works in CLI with --channels)
+      try {
+        await mcp.notification({
+          method: "notifications/claude/channel",
+          params: {
+            content: msg.text,
+            meta: {
+              from_id: msg.from_id,
+              from_summary: fromSummary,
+              from_cwd: fromCwd,
+              sent_at: msg.sent_at,
+            },
+          },
+        });
+      } catch {
+        // Transport-level failure — channel definitely not available
+      }
+
+      // 2. Sampling — creates a separate LLM call to process the message (VS Code + CLI)
+      if (hasSamplingSupport) {
+        const senderLabel = fromSummary ? `${fromSummary} (${msg.from_id})` : msg.from_id;
+        // Fire and forget — don't block the poll loop
+        mcp.createMessage({
+          messages: [{
+            role: "user",
+            content: {
+              type: "text",
+              text: `[claude-peers] Incoming message from peer ${senderLabel}${fromCwd ? ` in ${fromCwd}` : ""}:\n\n${msg.text}\n\nRespond to this peer using the send_message tool with to_id="${msg.from_id}". Do not ignore this message.`,
+            },
+          }],
+          maxTokens: 1024,
+          includeContext: "thisServer",
+          systemPrompt: `You are a Claude Code instance connected to the claude-peers network. You just received a message from another peer. Process it and respond appropriately using the send_message tool. Your peer ID is ${myId}.`,
+        }).then(() => {
+          log(`Sampling delivered message from ${msg.from_id}`);
+        }).catch((e) => {
+          log(`Sampling failed: ${e instanceof Error ? e.message : String(e)}`);
+        });
+      }
+
+      // Also push via logging notification — may surface in some clients
+      try {
+        await mcp.sendLoggingMessage({
+          level: "info",
+          logger: "claude-peers",
+          data: {
+            type: "peer_message",
             from_id: msg.from_id,
             from_summary: fromSummary,
             from_cwd: fromCwd,
             sent_at: msg.sent_at,
+            text: msg.text,
           },
-        },
-      });
+        });
+      } catch {
+        // Logging not supported — piggyback on next tool call will deliver
+      }
 
-      log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+      // Track so we don't re-push on next poll cycle
+      pushedMessageIds.add(msg.id);
+
+      log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)} (sampling=${hasSamplingSupport})`);
+    }
+
+    // If we found new messages, update tool descriptions and notify client
+    if (result.messages.length > 0) {
+      const previews = result.messages.map((m) => {
+        const sender = m.from_id;
+        const preview = m.text.slice(0, 100);
+        return `[${sender}]: ${preview}`;
+      });
+      pendingMessagePreview = previews.join(" | ");
+
+      // Tell client to re-fetch tool list — they'll see the message in check_messages description
+      try {
+        await mcp.notification({
+          method: "notifications/tools/list_changed",
+        });
+        log("Sent tools/list_changed notification");
+      } catch {
+        // Client doesn't support it
+      }
     }
   } catch (e) {
     // Broker might be down temporarily, don't crash
-    log(`Poll error: ${e instanceof Error ? e.message : String(e)}`);
+    log(`Poll error (${peerId}): ${e instanceof Error ? e.message : String(e)}`);
   }
+}
+
+async function pollAndPushMessages() {
+  const peerIds: PeerId[] = [];
+  if (myId) peerIds.push(myId);
+  for (const [_, entry] of desktopPeers) peerIds.push(entry.peerId);
+  await Promise.all(peerIds.map(pollForPeer));
 }
 
 // --- Startup ---
@@ -464,7 +783,11 @@ async function main() {
   log(`TTY: ${tty ?? "(unknown)"}`);
 
   // 3. Generate initial summary via gpt-5.4-nano (non-blocking, best-effort)
-  let initialSummary = "";
+  // CLAUDE_PEERS_NAME takes priority — it's the fixed identity for this session.
+  let initialSummary = PEER_NAME;
+  if (PEER_NAME) {
+    log(`Fixed identity: ${PEER_NAME}`);
+  }
   const summaryPromise = (async () => {
     try {
       const branch = await getGitBranch(myCwd);
@@ -475,7 +798,7 @@ async function main() {
         git_branch: branch,
         recent_files: recentFiles,
       });
-      if (summary) {
+      if (summary && !PEER_NAME) {
         initialSummary = summary;
         log(`Auto-summary: ${summary}`);
       }
@@ -488,15 +811,26 @@ async function main() {
   await Promise.race([summaryPromise, new Promise((r) => setTimeout(r, 3000))]);
 
   // 4. Register with broker
+  log(`Peer type: ${PEER_TYPE}`);
   const reg = await brokerFetch<RegisterResponse>("/register", {
     pid: process.pid,
     cwd: myCwd,
     git_root: myGitRoot,
     tty,
     summary: initialSummary,
+    peer_type: PEER_TYPE,
   });
   myId = reg.id;
   log(`Registered as peer ${myId}`);
+
+  // If broker restored a cached summary from a previous session, use it
+  if (reg.restored_summary) {
+    myLastSummary = reg.restored_summary;
+    initialSummary = reg.restored_summary;
+    log(`Restored summary from previous session: "${reg.restored_summary}"`);
+  } else if (initialSummary) {
+    myLastSummary = initialSummary;
+  }
 
   // If summary generation is still running, update it when done
   if (!initialSummary) {
@@ -504,6 +838,7 @@ async function main() {
       if (initialSummary && myId) {
         try {
           await brokerFetch("/set-summary", { id: myId, summary: initialSummary });
+          myLastSummary = initialSummary;
           log(`Late auto-summary applied: ${initialSummary}`);
         } catch {
           // Non-critical
@@ -516,18 +851,37 @@ async function main() {
   await mcp.connect(new StdioServerTransport());
   log("MCP connected");
 
+  // 5b. Detect client capabilities for message delivery
+  try {
+    const caps = mcp.getClientCapabilities();
+    hasSamplingSupport = !!caps?.sampling;
+    log(`Client capabilities: sampling=${hasSamplingSupport}`);
+  } catch {
+    log("Could not read client capabilities");
+  }
+
   // 6. Start polling for inbound messages
   const pollTimer = setInterval(pollAndPushMessages, POLL_INTERVAL_MS);
 
-  // 7. Start heartbeat
+  // 7. Start heartbeat (also re-registers if peer was cleaned up)
   const heartbeatTimer = setInterval(async () => {
+    const beats: Promise<void>[] = [];
     if (myId) {
-      try {
-        await brokerFetch("/heartbeat", { id: myId });
-      } catch {
-        // Non-critical
-      }
+      beats.push(
+        ensureRegistered()
+          .then(() => brokerFetch("/heartbeat", { id: myId }))
+          .then(() => {})
+          .catch(() => {})
+      );
     }
+    for (const [_, entry] of desktopPeers) {
+      beats.push(
+        brokerFetch("/heartbeat", { id: entry.peerId })
+          .then(() => {})
+          .catch(() => {})
+      );
+    }
+    await Promise.all(beats);
   }, HEARTBEAT_INTERVAL_MS);
 
   // 8. Clean up on exit
@@ -542,6 +896,16 @@ async function main() {
         // Best effort
       }
     }
+    // Unregister all desktop session peers
+    for (const [sessionId, entry] of desktopPeers) {
+      try {
+        await brokerFetch("/unregister", { id: entry.peerId });
+        log(`Unregistered desktop session ${sessionId}`);
+      } catch {
+        // Best effort
+      }
+    }
+    desktopPeers.clear();
     process.exit(0);
   };
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,6 +1,8 @@
 // Unique ID for each Claude Code instance (generated on registration)
 export type PeerId = string;
 
+export type PeerType = "cli" | "desktop";
+
 export interface Peer {
   id: PeerId;
   pid: number;
@@ -8,6 +10,7 @@ export interface Peer {
   git_root: string | null;
   tty: string | null;
   summary: string;
+  peer_type: PeerType;
   registered_at: string; // ISO timestamp
   last_seen: string; // ISO timestamp
 }
@@ -29,10 +32,12 @@ export interface RegisterRequest {
   git_root: string | null;
   tty: string | null;
   summary: string;
+  peer_type: PeerType;
 }
 
 export interface RegisterResponse {
   id: PeerId;
+  restored_summary?: string; // Set when a cached summary from a previous session was restored
 }
 
 export interface HeartbeatRequest {
@@ -64,4 +69,8 @@ export interface PollMessagesRequest {
 
 export interface PollMessagesResponse {
   messages: Message[];
+}
+
+export interface AckMessagesRequest {
+  message_ids: number[];
 }


### PR DESCRIPTION
## Summary

- **Fix PID-based dedup collision**: Desktop/Cowork sessions share a VM PID, so registering a new session would delete existing ones. Now skipped for desktop peers.
- **Fix summary cache collision**: Multiple desktop sessions in the same workspace overwrote each other's cached summaries. Desktop peers no longer read from or write to the summary cache.
- **Multi-tenant server routing**: `session_id`-based routing in the MCP server so each Cowork session maintains an independent peer identity (registration, heartbeat, message polling).
- **TTL cleanup & hygiene**: Delivered messages expire after 24h, summary cache after 7d. Stale desktop peers cleaned by heartbeat timeout (5 min). VACUUM on startup.
- **Code quality**: Explicit message ack flow, parallel polling, `ackMessages` helper, pruned `pushedMessageIds` set.

## Test plan

- [ ] Start two Cowork (desktop) sessions in the same workspace — both should appear in `list_peers`
- [ ] Set different summaries on each — they should not overwrite each other
- [ ] CLI sessions still get summary cache restore on restart
- [ ] `bun cli.ts peers` shows all active peers with correct types
- [ ] `bunx tsc --noEmit` passes clean