### PR TITLE
Fix broker SIGPIPE death on MCP session teardown

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -39,6 +39,7 @@ const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const BROKER_LOG = `${process.env.HOME}/.claude-peers-broker.log`;
 
 // --- Broker communication ---
 
@@ -70,11 +71,11 @@ async function ensureBroker(): Promise<void> {
     return;
   }
 
-  log("Starting broker daemon...");
+  log(`Starting broker daemon (log: ${BROKER_LOG})...`);
   const proc = Bun.spawn(["bun", BROKER_SCRIPT], {
-    stdio: ["ignore", "ignore", "inherit"],
-    // Detach so the broker survives if this MCP server exits
-    // On macOS/Linux, the broker will keep running
+    // Redirect stderr to a log file instead of inheriting — inheriting causes
+    // SIGPIPE to kill the broker when Claude Code closes the MCP server's pipe.
+    stdio: ["ignore", "ignore", Bun.file(BROKER_LOG)],
   });
 
   // Unref so this process can exit without waiting for the broker


### PR DESCRIPTION
## Summary

- Redirect broker stderr to `~/.claude-peers-broker.log` instead of inheriting the MCP server's pipe
- The inherited pipe causes SIGPIPE when Claude Code tears down the session, killing the broker and breaking any other peers still registered

## What was happening

When `ensureBroker()` spawns the broker with `stdio: ["ignore", "ignore", "inherit"]`, the broker inherits fd 2 from the MCP server process. That fd is a pipe whose read end is held by Claude Code. When the CC session ends, Claude Code closes the read end — the next time the broker writes to stderr (cleanup log, etc.), it gets SIGPIPE and dies. Any other MCP servers still registered with that broker lose their connection.

## Fix

Write broker stderr to a dedicated log file (`~/.claude-peers-broker.log`) via `Bun.file()`. The broker now survives MCP server exits and keeps serving other peers.

## Test plan
- Start two `cc` sessions, verify both register as peers
- Exit one session, verify broker stays alive (`curl http://127.0.0.1:7899/health`)
- Verify the remaining session can still list peers and send messages

t. Clanker :robot: