### PR TITLE
feat: cross-container support (Docker sandbox ↔ host broker)

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -217,7 +217,7 @@ function handleUnregister(body: { id: string }): void {
 
 Bun.serve({
   port: PORT,
-  hostname: "127.0.0.1",
+  hostname: process.env.CLAUDE_PEERS_BIND ?? "127.0.0.1",
   async fetch(req) {
     const url = new URL(req.url);
     const path = url.pathname;

--- a/broker.ts
+++ b/broker.ts
@@ -58,18 +58,16 @@ db.run(`
   )
 `);
 
-// Clean up stale peers (PIDs that no longer exist) on startup
+// Clean up stale peers — use heartbeat staleness instead of PID check
+// so cross-container peers (different PID namespaces) aren't wrongly removed.
+const STALE_PEER_TIMEOUT_MS = 60_000;
+
 function cleanStalePeers() {
-  const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
-  for (const peer of peers) {
-    try {
-      // Check if process is still alive (signal 0 doesn't kill, just checks)
-      process.kill(peer.pid, 0);
-    } catch {
-      // Process doesn't exist, remove it
-      db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
-      db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
-    }
+  const cutoff = new Date(Date.now() - STALE_PEER_TIMEOUT_MS).toISOString();
+  const stale = db.query("SELECT id FROM peers WHERE last_seen < ?").all(cutoff) as { id: string }[];
+  for (const peer of stale) {
+    db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
+    db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
   }
 }
 
@@ -184,17 +182,9 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
     peers = peers.filter((p) => p.id !== body.exclude_id);
   }
 
-  // Verify each peer's process is still alive
-  return peers.filter((p) => {
-    try {
-      process.kill(p.pid, 0);
-      return true;
-    } catch {
-      // Clean up dead peer
-      deletePeer.run(p.id);
-      return false;
-    }
-  });
+  // Filter out stale peers by heartbeat (no PID check — cross-container safe)
+  const cutoff = new Date(Date.now() - STALE_PEER_TIMEOUT_MS).toISOString();
+  return peers.filter((p) => p.last_seen >= cutoff);
 }
 
 function handleSendMessage(body: SendMessageRequest): { ok: boolean; error?: string } {

--- a/server.ts
+++ b/server.ts
@@ -35,7 +35,7 @@ import {
 // --- Configuration ---
 
 const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
-const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
+const BROKER_URL = process.env.CLAUDE_PEERS_BROKER_URL ?? `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;

--- a/server.ts
+++ b/server.ts
@@ -139,6 +139,9 @@ let myId: PeerId | null = null;
 let myCwd = process.cwd();
 let myGitRoot: string | null = null;
 
+// Buffer for messages consumed by polling but not delivered via channel push
+const undeliveredMessages: Array<Message & { from_summary?: string; from_cwd?: string }> = [];
+
 // --- MCP Server ---
 
 const mcp = new Server(
@@ -364,20 +367,24 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
         };
       }
       try {
+        // Collect from broker + drain the local buffer (messages consumed by poll but not pushed via channel)
         const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
-        if (result.messages.length === 0) {
+        const buffered = undeliveredMessages.splice(0);
+        const allMessages = [...buffered, ...result.messages];
+
+        if (allMessages.length === 0) {
           return {
             content: [{ type: "text" as const, text: "No new messages." }],
           };
         }
-        const lines = result.messages.map(
+        const lines = allMessages.map(
           (m) => `From ${m.from_id} (${m.sent_at}):\n${m.text}`
         );
         return {
           content: [
             {
               type: "text" as const,
-              text: `${result.messages.length} new message(s):\n\n${lines.join("\n\n---\n\n")}`,
+              text: `${allMessages.length} new message(s):\n\n${lines.join("\n\n---\n\n")}`,
             },
           ],
         };
@@ -426,21 +433,31 @@ async function pollAndPushMessages() {
         // Non-critical, proceed without sender info
       }
 
-      // Push as channel notification — this is what makes it immediate
-      await mcp.notification({
-        method: "notifications/claude/channel",
-        params: {
-          content: msg.text,
-          meta: {
-            from_id: msg.from_id,
-            from_summary: fromSummary,
-            from_cwd: fromCwd,
-            sent_at: msg.sent_at,
-          },
-        },
-      });
+      // Buffer for check_messages fallback (channel push may silently drop when blocked by org policy)
+      const bufferedMsg = { ...msg, from_summary: fromSummary, from_cwd: fromCwd };
+      undeliveredMessages.push(bufferedMsg);
 
-      log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+      // Also try channel push for instant delivery (best-effort)
+      try {
+        await mcp.notification({
+          method: "notifications/claude/channel",
+          params: {
+            content: msg.text,
+            meta: {
+              from_id: msg.from_id,
+              from_summary: fromSummary,
+              from_cwd: fromCwd,
+              sent_at: msg.sent_at,
+            },
+          },
+        });
+        // Channel push succeeded — remove from buffer to prevent unbounded growth
+        const idx = undeliveredMessages.indexOf(bufferedMsg);
+        if (idx !== -1) undeliveredMessages.splice(idx, 1);
+        log(`Pushed message from ${msg.from_id}: ${msg.text.slice(0, 80)}`);
+      } catch {
+        log(`Channel push failed for message from ${msg.from_id}`);
+      }
     }
   } catch (e) {
     // Broker might be down temporarily, don't crash


### PR DESCRIPTION
## Summary

Enables Claude Code MCP servers running inside Docker containers (e.g. sandboxed environments) to connect to a host broker, and vice versa. Four changes across `broker.ts` and `server.ts`:

- **Heartbeat-based stale peer cleanup** — replace `process.kill(pid, 0)` PID checks with a 60s heartbeat timeout. PID checks fail across container boundaries (different PID namespaces), causing cross-container peers to be incorrectly evicted.
- **Configurable bind address** (`CLAUDE_PEERS_BIND`) — default stays `127.0.0.1` (localhost-only) since the broker has no authentication. Docker users opt in with `CLAUDE_PEERS_BIND=0.0.0.0` to accept connections from containers via `host.docker.internal`.
- **Configurable broker URL** (`CLAUDE_PEERS_BROKER_URL`) — let containerized MCP servers point to the host broker (e.g. `http://host.docker.internal:7899`). Falls back to `http://127.0.0.1:{port}`.
- **Always-buffer polled messages** — the poll loop buffers messages locally before attempting channel push. On success, the message is removed from the buffer. On failure (org policy, container environment), it stays buffered and `check_messages` drains it as fallback. Prevents both silent message loss and unbounded buffer growth.

## Use case

```
┌─────────────────────────┐     ┌──────────────────────────────┐
│  Host machine            │     │  Docker container (sandbox)   │
│                          │     │                               │
│  broker.ts (:7899)  ◄────┼─────┼── server.ts (MCP)            │
│  (CLAUDE_PEERS_BIND=     │     │   CLAUDE_PEERS_BROKER_URL=    │
│   0.0.0.0)               │     │   http://host.docker.internal │
│                          │     │   :7899                       │
│                          │     │                               │
│  server.ts (MCP) ────────┼─────┼──► peers visible both ways    │
└─────────────────────────┘     └──────────────────────────────┘
```

All changes are backwards-compatible — without env vars set, behavior is unchanged (broker binds `127.0.0.1`, MCP server connects to `127.0.0.1`).

## Related PRs

- #28 — overlaps on `CLAUDE_PEERS_BROKER_URL` and `CLAUDE_PEERS_BIND` (cross-machine support). This PR focuses specifically on the container use case with a smaller diff.
- #10 — overlaps on heartbeat-based stale peer cleanup
- #11, #9 — overlap on silent message loss fix. This PR takes a simpler approach (local buffer + best-effort push) without adding a new broker endpoint.

## Test plan

- [ ] Single-machine setup works as before (no env vars needed, broker binds 127.0.0.1)
- [ ] Host broker with `CLAUDE_PEERS_BIND=0.0.0.0` accepts connections from Docker container
- [ ] Container MCP server with `CLAUDE_PEERS_BROKER_URL=http://host.docker.internal:7899` registers and exchanges messages
- [ ] Stale peers are cleaned up by heartbeat timeout, not PID check
- [ ] `CLAUDE_PEERS_BIND=127.0.0.1` restricts broker to localhost-only (default)
- [ ] Messages are recoverable via `check_messages` when channel push is unavailable
- [ ] Buffer does not grow unboundedly when channel push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)