### PR TITLE
feat: named aliases (CLAUDE_PEER_NAME) + process-ancestry tmux detection

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -58,6 +58,21 @@ db.run(`
   )
 `);
 
+// --- Idempotent schema migrations (F1+F2) ---
+const migrationColumns = [
+  { name: "name", type: "TEXT" },
+  { name: "tmux_session", type: "TEXT" },
+  { name: "tmux_window_index", type: "TEXT" },
+  { name: "tmux_window_name", type: "TEXT" },
+];
+for (const col of migrationColumns) {
+  try {
+    db.run(`ALTER TABLE peers ADD COLUMN ${col.name} ${col.type}`);
+  } catch {
+    // Column already exists — safe to ignore
+  }
+}
+
 // Clean up stale peers (PIDs that no longer exist) on startup
 function cleanStalePeers() {
   const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
@@ -81,8 +96,8 @@ setInterval(cleanStalePeers, 30_000);
 // --- Prepared statements ---
 
 const insertPeer = db.prepare(`
-  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, registered_at, last_seen)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO peers (id, pid, cwd, git_root, tty, name, tmux_session, tmux_window_index, tmux_window_name, summary, registered_at, last_seen)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateLastSeen = db.prepare(`
@@ -145,7 +160,7 @@ function handleRegister(body: RegisterRequest): RegisterResponse {
     deletePeer.run(existing.id);
   }
 
-  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now);
+  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.name ?? null, body.tmux_session ?? null, body.tmux_window_index ?? null, body.tmux_window_name ?? null, body.summary, now, now);
   return { id };
 }
 

--- a/server.ts
+++ b/server.ts
@@ -133,6 +133,62 @@ function getTty(): string | null {
   return null;
 }
 
+// --- F2: Process-ancestry tmux detection ---
+
+interface TmuxPaneInfo {
+  session: string;
+  window_index: string;
+  window_name: string;
+}
+
+async function detectTmuxPane(): Promise<TmuxPaneInfo | null> {
+  try {
+    // 1. Get all tmux panes with their pane_pid
+    const listProc = Bun.spawn(
+      ["tmux", "list-panes", "-a", "-F", "#{pane_pid} #{session_name} #{window_index} #{window_name}"],
+      { stdout: "pipe", stderr: "ignore" }
+    );
+    const listText = await new Response(listProc.stdout).text();
+    const listCode = await listProc.exited;
+    if (listCode !== 0) return null;
+
+    // 2. Parse into a map keyed by pane_pid
+    const paneMap = new Map<number, TmuxPaneInfo>();
+    for (const line of listText.trim().split("\n")) {
+      const parts = line.trim().split(" ");
+      if (parts.length >= 4) {
+        const pid = parseInt(parts[0]!, 10);
+        if (!isNaN(pid)) {
+          paneMap.set(pid, {
+            session: parts[1]!,
+            window_index: parts[2]!,
+            window_name: parts.slice(3).join(" "),
+          });
+        }
+      }
+    }
+
+    if (paneMap.size === 0) return null;
+
+    // 3. Walk upward from process.ppid
+    let currentPid = process.ppid;
+    for (let i = 0; i < 20; i++) {
+      if (paneMap.has(currentPid)) {
+        return paneMap.get(currentPid)!;
+      }
+      // Get parent of currentPid
+      const psProc = Bun.spawnSync(["ps", "-o", "ppid=", "-p", String(currentPid)]);
+      const ppidStr = new TextDecoder().decode(psProc.stdout).trim();
+      const parentPid = parseInt(ppidStr, 10);
+      if (isNaN(parentPid) || parentPid <= 1) break;
+      currentPid = parentPid;
+    }
+  } catch {
+    // tmux not installed or not running — graceful failure
+  }
+  return null;
+}
+
 // --- State ---
 
 let myId: PeerId | null = null;
@@ -219,6 +275,24 @@ const TOOLS = [
     },
   },
   {
+    name: "find_peer",
+    description:
+      "Find Claude Code instances by human-readable name (set via CLAUDE_PEER_NAME env var) or tmux session. Returns matching peer IDs.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string" as const,
+          description: "Exact match on the peer's CLAUDE_PEER_NAME",
+        },
+        tmux: {
+          type: "string" as const,
+          description: "Match against tmux session name",
+        },
+      },
+    },
+  },
+  {
     name: "check_messages",
     description:
       "Manually check for new messages from other Claude Code instances. Messages are normally pushed automatically via channel notifications, but you can use this as a fallback.",
@@ -266,8 +340,10 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
             `PID: ${p.pid}`,
             `CWD: ${p.cwd}`,
           ];
+          if (p.name) parts.push(`Name: ${p.name}`);
           if (p.git_root) parts.push(`Repo: ${p.git_root}`);
           if (p.tty) parts.push(`TTY: ${p.tty}`);
+          if (p.tmux_session) parts.push(`Tmux: ${p.tmux_session}:${p.tmux_window_index}:${p.tmux_window_name}`);
           if (p.summary) parts.push(`Summary: ${p.summary}`);
           parts.push(`Last seen: ${p.last_seen}`);
           return parts.join("\n  ");
@@ -351,6 +427,42 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
               text: `Error setting summary: ${e instanceof Error ? e.message : String(e)}`,
             },
           ],
+          isError: true,
+        };
+      }
+    }
+
+    case "find_peer": {
+      const { name: findName, tmux: findTmux } = args as { name?: string; tmux?: string };
+      if (!findName && !findTmux) {
+        return {
+          content: [{ type: "text" as const, text: "Provide at least one of: name, tmux" }],
+          isError: true,
+        };
+      }
+      try {
+        const allPeers = await brokerFetch<Peer[]>("/list-peers", {
+          scope: "machine" as const,
+          cwd: myCwd,
+          git_root: myGitRoot,
+        });
+        const matches = allPeers.filter((p) => {
+          if (findName && p.name !== findName) return false;
+          if (findTmux && p.tmux_session !== findTmux) return false;
+          return true;
+        });
+        if (matches.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: `No peers found matching${findName ? ` name="${findName}"` : ""}${findTmux ? ` tmux="${findTmux}"` : ""}` }],
+          };
+        }
+        const lines = matches.map((p) => `${p.id}${p.name ? ` (${p.name})` : ""}${p.tmux_session ? ` [tmux ${p.tmux_session}:${p.tmux_window_name}]` : ""}`);
+        return {
+          content: [{ type: "text" as const, text: `Found ${matches.length} peer(s):\n${lines.join("\n")}` }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Error finding peers: ${e instanceof Error ? e.message : String(e)}` }],
           isError: true,
         };
       }
@@ -458,10 +570,14 @@ async function main() {
   myCwd = process.cwd();
   myGitRoot = await getGitRoot(myCwd);
   const tty = getTty();
+  const peerName = process.env.CLAUDE_PEER_NAME ?? null;
+  const tmuxInfo = await detectTmuxPane();
 
   log(`CWD: ${myCwd}`);
   log(`Git root: ${myGitRoot ?? "(none)"}`);
   log(`TTY: ${tty ?? "(unknown)"}`);
+  if (peerName) log(`Peer name: ${peerName}`);
+  if (tmuxInfo) log(`Tmux: ${tmuxInfo.session}:${tmuxInfo.window_index}:${tmuxInfo.window_name}`);
 
   // 3. Generate initial summary via gpt-5.4-nano (non-blocking, best-effort)
   let initialSummary = "";
@@ -487,12 +603,21 @@ async function main() {
   // Wait briefly for summary, but don't block startup
   await Promise.race([summaryPromise, new Promise((r) => setTimeout(r, 3000))]);
 
+  // Prepend tmux tag to summary if detected
+  if (tmuxInfo && initialSummary) {
+    initialSummary = `[tmux ${tmuxInfo.session}:${tmuxInfo.window_name}] ${initialSummary}`;
+  }
+
   // 4. Register with broker
   const reg = await brokerFetch<RegisterResponse>("/register", {
     pid: process.pid,
     cwd: myCwd,
     git_root: myGitRoot,
     tty,
+    name: peerName,
+    tmux_session: tmuxInfo?.session ?? null,
+    tmux_window_index: tmuxInfo?.window_index ?? null,
+    tmux_window_name: tmuxInfo?.window_name ?? null,
     summary: initialSummary,
   });
   myId = reg.id;
@@ -502,6 +627,10 @@ async function main() {
   if (!initialSummary) {
     summaryPromise.then(async () => {
       if (initialSummary && myId) {
+        // Prepend tmux tag to late summary
+        if (tmuxInfo) {
+          initialSummary = `[tmux ${tmuxInfo.session}:${tmuxInfo.window_name}] ${initialSummary}`;
+        }
         try {
           await brokerFetch("/set-summary", { id: myId, summary: initialSummary });
           log(`Late auto-summary applied: ${initialSummary}`);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -7,6 +7,10 @@ export interface Peer {
   cwd: string;
   git_root: string | null;
   tty: string | null;
+  name: string | null;
+  tmux_session: string | null;
+  tmux_window_index: string | null;
+  tmux_window_name: string | null;
   summary: string;
   registered_at: string; // ISO timestamp
   last_seen: string; // ISO timestamp
@@ -28,6 +32,10 @@ export interface RegisterRequest {
   cwd: string;
   git_root: string | null;
   tty: string | null;
+  name: string | null;
+  tmux_session: string | null;
+  tmux_window_index: string | null;
+  tmux_window_name: string | null;
   summary: string;
 }
 

--- a/tests/f1-f2.test.ts
+++ b/tests/f1-f2.test.ts
@@ -1,0 +1,532 @@
+/**
+ * Tests for F1 (named aliases) and F2 (tmux process-ancestry detection).
+ *
+ * These tests verify the broker schema migrations, registration with
+ * F1+F2 fields, list_peers output, and find_peer filtering.
+ * F2's detectTmuxPane() is tested via a mock since tmux may not be available in CI.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { Database } from "bun:sqlite";
+import type { Peer, RegisterRequest } from "../shared/types.ts";
+
+// --- Broker-level tests (schema + registration + queries) ---
+
+describe("F1+F2 broker schema migrations", () => {
+  let db: Database;
+
+  beforeAll(() => {
+    db = new Database(":memory:");
+    db.run("PRAGMA journal_mode = WAL");
+
+    // Create the original schema (pre-F1+F2)
+    db.run(`
+      CREATE TABLE IF NOT EXISTS peers (
+        id TEXT PRIMARY KEY,
+        pid INTEGER NOT NULL,
+        cwd TEXT NOT NULL,
+        git_root TEXT,
+        tty TEXT,
+        summary TEXT NOT NULL DEFAULT '',
+        registered_at TEXT NOT NULL,
+        last_seen TEXT NOT NULL
+      )
+    `);
+
+    // Run idempotent migrations (same as broker.ts)
+    const migrationColumns = [
+      { name: "name", type: "TEXT" },
+      { name: "tmux_session", type: "TEXT" },
+      { name: "tmux_window_index", type: "TEXT" },
+      { name: "tmux_window_name", type: "TEXT" },
+    ];
+    for (const col of migrationColumns) {
+      try {
+        db.run(`ALTER TABLE peers ADD COLUMN ${col.name} ${col.type}`);
+      } catch {
+        // Column already exists
+      }
+    }
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  test("migration adds 4 new columns", () => {
+    const info = db.prepare("PRAGMA table_info(peers)").all() as Array<{ name: string }>;
+    const colNames = info.map((c) => c.name);
+    expect(colNames).toContain("name");
+    expect(colNames).toContain("tmux_session");
+    expect(colNames).toContain("tmux_window_index");
+    expect(colNames).toContain("tmux_window_name");
+  });
+
+  test("migrations are idempotent (re-running does not error)", () => {
+    const migrationColumns = [
+      { name: "name", type: "TEXT" },
+      { name: "tmux_session", type: "TEXT" },
+      { name: "tmux_window_index", type: "TEXT" },
+      { name: "tmux_window_name", type: "TEXT" },
+    ];
+    // Run again — should not throw
+    for (const col of migrationColumns) {
+      expect(() => {
+        try {
+          db.run(`ALTER TABLE peers ADD COLUMN ${col.name} ${col.type}`);
+        } catch {
+          // Expected: column already exists
+        }
+      }).not.toThrow();
+    }
+  });
+
+  test("F1: insert peer with name field", () => {
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO peers (id, pid, cwd, git_root, tty, name, tmux_session, tmux_window_index, tmux_window_name, summary, registered_at, last_seen)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["peer-1", 12345, "/home/test", null, "pts/1", "mary", null, null, null, "test summary", now, now]
+    );
+
+    const peer = db.query("SELECT * FROM peers WHERE id = ?").get("peer-1") as Peer;
+    expect(peer.name).toBe("mary");
+    expect(peer.tmux_session).toBeNull();
+  });
+
+  test("F1: insert peer without name (backward compat)", () => {
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO peers (id, pid, cwd, git_root, tty, name, tmux_session, tmux_window_index, tmux_window_name, summary, registered_at, last_seen)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["peer-2", 12346, "/home/test", null, "pts/2", null, null, null, null, "", now, now]
+    );
+
+    const peer = db.query("SELECT * FROM peers WHERE id = ?").get("peer-2") as Peer;
+    expect(peer.name).toBeNull();
+  });
+
+  test("F2: insert peer with tmux fields", () => {
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO peers (id, pid, cwd, git_root, tty, name, tmux_session, tmux_window_index, tmux_window_name, summary, registered_at, last_seen)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["peer-3", 12347, "/home/test", null, "pts/3", "winston", "mgt", "1", "claude", "arch work", now, now]
+    );
+
+    const peer = db.query("SELECT * FROM peers WHERE id = ?").get("peer-3") as Peer;
+    expect(peer.name).toBe("winston");
+    expect(peer.tmux_session).toBe("mgt");
+    expect(peer.tmux_window_index).toBe("1");
+    expect(peer.tmux_window_name).toBe("claude");
+  });
+
+  test("F2: insert peer outside tmux (null tmux fields)", () => {
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO peers (id, pid, cwd, git_root, tty, name, tmux_session, tmux_window_index, tmux_window_name, summary, registered_at, last_seen)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["peer-4", 12348, "/home/test", null, "pts/4", null, null, null, null, "", now, now]
+    );
+
+    const peer = db.query("SELECT * FROM peers WHERE id = ?").get("peer-4") as Peer;
+    expect(peer.tmux_session).toBeNull();
+    expect(peer.tmux_window_index).toBeNull();
+    expect(peer.tmux_window_name).toBeNull();
+  });
+
+  test("find_peer: filter by name", () => {
+    const peers = db.query("SELECT * FROM peers WHERE name = ?").all("mary") as Peer[];
+    expect(peers.length).toBe(1);
+    expect(peers[0]!.id).toBe("peer-1");
+  });
+
+  test("find_peer: filter by tmux_session", () => {
+    const peers = db.query("SELECT * FROM peers WHERE tmux_session = ?").all("mgt") as Peer[];
+    expect(peers.length).toBe(1);
+    expect(peers[0]!.id).toBe("peer-3");
+  });
+
+  test("find_peer: filter by name AND tmux_session", () => {
+    const peers = db
+      .query("SELECT * FROM peers WHERE name = ? AND tmux_session = ?")
+      .all("winston", "mgt") as Peer[];
+    expect(peers.length).toBe(1);
+    expect(peers[0]!.id).toBe("peer-3");
+  });
+
+  test("find_peer: no match returns empty", () => {
+    const peers = db.query("SELECT * FROM peers WHERE name = ?").all("nonexistent") as Peer[];
+    expect(peers.length).toBe(0);
+  });
+
+  test("find_peer: name match + wrong tmux returns empty", () => {
+    const peers = db
+      .query("SELECT * FROM peers WHERE name = ? AND tmux_session = ?")
+      .all("mary", "nonexistent") as Peer[];
+    expect(peers.length).toBe(0);
+  });
+
+  test("list_peers returns all F1+F2 fields", () => {
+    const peers = db.query("SELECT * FROM peers").all() as Peer[];
+    expect(peers.length).toBe(4);
+
+    // Verify all peers have the new fields (even if null)
+    for (const peer of peers) {
+      expect("name" in peer).toBe(true);
+      expect("tmux_session" in peer).toBe(true);
+      expect("tmux_window_index" in peer).toBe(true);
+      expect("tmux_window_name" in peer).toBe(true);
+    }
+  });
+
+  test("old peers without new columns still queryable", () => {
+    // Simulate a pre-migration peer (only original columns)
+    db.run(
+      `INSERT INTO peers (id, pid, cwd, summary, registered_at, last_seen)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      ["peer-old", 99999, "/old", "", new Date().toISOString(), new Date().toISOString()]
+    );
+
+    const peer = db.query("SELECT * FROM peers WHERE id = ?").get("peer-old") as Peer;
+    expect(peer.id).toBe("peer-old");
+    expect(peer.name).toBeNull();
+    expect(peer.tmux_session).toBeNull();
+  });
+});
+
+// --- Type contract tests ---
+
+describe("F1+F2 type contracts", () => {
+  test("RegisterRequest accepts F1+F2 fields", () => {
+    const req: RegisterRequest = {
+      pid: 12345,
+      cwd: "/home/test",
+      git_root: null,
+      tty: "pts/1",
+      name: "test-peer",
+      tmux_session: "dev",
+      tmux_window_index: "0",
+      tmux_window_name: "main",
+      summary: "test",
+    };
+    expect(req.name).toBe("test-peer");
+    expect(req.tmux_session).toBe("dev");
+  });
+
+  test("RegisterRequest accepts null F1+F2 fields (backward compat)", () => {
+    const req: RegisterRequest = {
+      pid: 12345,
+      cwd: "/home/test",
+      git_root: null,
+      tty: null,
+      name: null,
+      tmux_session: null,
+      tmux_window_index: null,
+      tmux_window_name: null,
+      summary: "",
+    };
+    expect(req.name).toBeNull();
+    expect(req.tmux_session).toBeNull();
+  });
+
+  test("Peer interface includes F1+F2 fields", () => {
+    const peer: Peer = {
+      id: "test",
+      pid: 1,
+      cwd: "/",
+      git_root: null,
+      tty: null,
+      name: "barry",
+      tmux_session: "mgt",
+      tmux_window_index: "2",
+      tmux_window_name: "build",
+      summary: "",
+      registered_at: "",
+      last_seen: "",
+    };
+    expect(peer.name).toBe("barry");
+    expect(peer.tmux_session).toBe("mgt");
+    expect(peer.tmux_window_index).toBe("2");
+    expect(peer.tmux_window_name).toBe("build");
+  });
+});
+
+// --- detectTmuxPane unit tests ---
+
+describe("F2 detectTmuxPane parsing logic", () => {
+  // Test the parsing logic that detectTmuxPane uses internally.
+  // We can't call detectTmuxPane directly from tests (it shells out),
+  // so we test the parsing algorithm in isolation.
+
+  function parseTmuxOutput(output: string): Map<number, { session: string; window_index: string; window_name: string }> {
+    const paneMap = new Map<number, { session: string; window_index: string; window_name: string }>();
+    for (const line of output.trim().split("\n")) {
+      const parts = line.trim().split(" ");
+      if (parts.length >= 4) {
+        const pid = parseInt(parts[0]!, 10);
+        if (!isNaN(pid)) {
+          paneMap.set(pid, {
+            session: parts[1]!,
+            window_index: parts[2]!,
+            window_name: parts.slice(3).join(" "),
+          });
+        }
+      }
+    }
+    return paneMap;
+  }
+
+  test("parses standard tmux list-panes output", () => {
+    const output = `12345 main 0 bash
+67890 dev 1 vim
+11111 mgt 2 claude code`;
+
+    const map = parseTmuxOutput(output);
+    expect(map.size).toBe(3);
+    expect(map.get(12345)).toEqual({ session: "main", window_index: "0", window_name: "bash" });
+    expect(map.get(67890)).toEqual({ session: "dev", window_index: "1", window_name: "vim" });
+    // Window name with space preserved
+    expect(map.get(11111)).toEqual({ session: "mgt", window_index: "2", window_name: "claude code" });
+  });
+
+  test("handles empty output", () => {
+    const map = parseTmuxOutput("");
+    expect(map.size).toBe(0);
+  });
+
+  test("handles single pane", () => {
+    const output = "2505121 4 0 bash";
+    const map = parseTmuxOutput(output);
+    expect(map.size).toBe(1);
+    expect(map.get(2505121)).toEqual({ session: "4", window_index: "0", window_name: "bash" });
+  });
+
+  test("skips malformed lines (too few fields)", () => {
+    const output = `12345 main 0 bash
+bad line
+67890 dev 1 vim`;
+
+    const map = parseTmuxOutput(output);
+    expect(map.size).toBe(2);
+    expect(map.has(12345)).toBe(true);
+    expect(map.has(67890)).toBe(true);
+  });
+
+  test("skips lines with non-numeric pid", () => {
+    const output = `notapid main 0 bash
+12345 dev 1 vim`;
+
+    const map = parseTmuxOutput(output);
+    expect(map.size).toBe(1);
+    expect(map.has(12345)).toBe(true);
+  });
+
+  test("ancestry walk simulation: match within 20 iterations", () => {
+    // Simulate the walk: pid chain 100 -> 90 -> 80 -> 70 (match at 70)
+    const paneMap = new Map([[70, { session: "test", window_index: "0", window_name: "bash" }]]);
+    const parentChain: Record<number, number> = { 100: 90, 90: 80, 80: 70, 70: 1 };
+
+    let currentPid = 100;
+    let result: { session: string; window_index: string; window_name: string } | null = null;
+    for (let i = 0; i < 20; i++) {
+      if (paneMap.has(currentPid)) {
+        result = paneMap.get(currentPid)!;
+        break;
+      }
+      const parent = parentChain[currentPid];
+      if (!parent || parent <= 1) break;
+      currentPid = parent;
+    }
+
+    expect(result).toEqual({ session: "test", window_index: "0", window_name: "bash" });
+  });
+
+  test("ancestry walk simulation: no match within 20 iterations", () => {
+    const paneMap = new Map([[1, { session: "unreachable", window_index: "0", window_name: "bash" }]]);
+    // Chain never reaches pid 1 within 20 steps (goes 100 -> 99 -> ... -> 81)
+    const parentChain: Record<number, number> = {};
+    for (let i = 100; i > 80; i--) {
+      parentChain[i] = i - 1;
+    }
+    parentChain[81] = 0; // terminates before reaching paneMap entry
+
+    let currentPid = 100;
+    let result: { session: string; window_index: string; window_name: string } | null = null;
+    for (let i = 0; i < 20; i++) {
+      if (paneMap.has(currentPid)) {
+        result = paneMap.get(currentPid)!;
+        break;
+      }
+      const parent = parentChain[currentPid];
+      if (!parent || parent <= 1) break;
+      currentPid = parent;
+    }
+
+    expect(result).toBeNull();
+  });
+
+  test("ancestry walk simulation: ppid=1 terminates early", () => {
+    const paneMap = new Map([[999, { session: "test", window_index: "0", window_name: "bash" }]]);
+    const parentChain: Record<number, number> = { 100: 1 }; // immediate init
+
+    let currentPid = 100;
+    let result: { session: string; window_index: string; window_name: string } | null = null;
+    for (let i = 0; i < 20; i++) {
+      if (paneMap.has(currentPid)) {
+        result = paneMap.get(currentPid)!;
+        break;
+      }
+      const parent = parentChain[currentPid];
+      if (!parent || parent <= 1) break;
+      currentPid = parent;
+    }
+
+    expect(result).toBeNull();
+  });
+});
+
+// --- Integration test: live broker round-trip ---
+
+describe("F1+F2 live broker integration", () => {
+  const BROKER_PORT = 17899; // Use non-standard port to avoid conflicts
+  let brokerProc: ReturnType<typeof Bun.spawn>;
+  const brokerUrl = `http://127.0.0.1:${BROKER_PORT}`;
+  const TEST_DB = "/tmp/claude-peers-test-f1f2.db";
+
+  beforeAll(async () => {
+    // Clean up any old test DB
+    try { await Bun.write(TEST_DB, ""); Bun.spawnSync(["rm", "-f", TEST_DB]); } catch {}
+
+    brokerProc = Bun.spawn(["bun", "/home/manzo/claude-peers-mcp/broker.ts"], {
+      env: { ...process.env, CLAUDE_PEERS_PORT: String(BROKER_PORT), CLAUDE_PEERS_DB: TEST_DB },
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    // Wait for broker to start
+    for (let i = 0; i < 30; i++) {
+      try {
+        const res = await fetch(`${brokerUrl}/health`, { signal: AbortSignal.timeout(500) });
+        if (res.ok) break;
+      } catch {}
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  afterAll(() => {
+    brokerProc.kill();
+    Bun.spawnSync(["rm", "-f", TEST_DB]);
+  });
+
+  async function brokerFetch<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(`${brokerUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return res.json() as Promise<T>;
+  }
+
+  test("F1: register with name, retrieve via list_peers", async () => {
+    const reg = await brokerFetch<{ id: string }>("/register", {
+      pid: process.pid,
+      cwd: "/home/test",
+      git_root: null,
+      tty: "pts/99",
+      name: "test-mary",
+      tmux_session: null,
+      tmux_window_index: null,
+      tmux_window_name: null,
+      summary: "test peer",
+    });
+
+    expect(reg.id).toBeTruthy();
+
+    const peers = await brokerFetch<Peer[]>("/list-peers", {
+      scope: "machine",
+      cwd: "/",
+      git_root: null,
+    });
+
+    const found = peers.find((p) => p.id === reg.id);
+    expect(found).toBeTruthy();
+    expect(found!.name).toBe("test-mary");
+  });
+
+  test("F1: register without name (backward compat)", async () => {
+    const reg = await brokerFetch<{ id: string }>("/register", {
+      pid: process.pid + 1, // fake different PID
+      cwd: "/home/test2",
+      git_root: null,
+      tty: null,
+      name: null,
+      tmux_session: null,
+      tmux_window_index: null,
+      tmux_window_name: null,
+      summary: "",
+    });
+
+    const peers = await brokerFetch<Peer[]>("/list-peers", {
+      scope: "machine",
+      cwd: "/",
+      git_root: null,
+    });
+
+    const found = peers.find((p) => p.id === reg.id);
+    expect(found).toBeTruthy();
+    expect(found!.name).toBeNull();
+  });
+
+  test("F2: register with tmux fields, retrieve via list_peers", async () => {
+    const reg = await brokerFetch<{ id: string }>("/register", {
+      pid: process.pid + 2,
+      cwd: "/home/test3",
+      git_root: null,
+      tty: "pts/50",
+      name: "test-winston",
+      tmux_session: "dev",
+      tmux_window_index: "3",
+      tmux_window_name: "architect",
+      summary: "arch work",
+    });
+
+    const peers = await brokerFetch<Peer[]>("/list-peers", {
+      scope: "machine",
+      cwd: "/",
+      git_root: null,
+    });
+
+    const found = peers.find((p) => p.id === reg.id);
+    expect(found).toBeTruthy();
+    expect(found!.tmux_session).toBe("dev");
+    expect(found!.tmux_window_index).toBe("3");
+    expect(found!.tmux_window_name).toBe("architect");
+  });
+
+  test("F2: register outside tmux (null fields)", async () => {
+    const reg = await brokerFetch<{ id: string }>("/register", {
+      pid: process.pid + 3,
+      cwd: "/home/test4",
+      git_root: null,
+      tty: null,
+      name: null,
+      tmux_session: null,
+      tmux_window_index: null,
+      tmux_window_name: null,
+      summary: "",
+    });
+
+    const peers = await brokerFetch<Peer[]>("/list-peers", {
+      scope: "machine",
+      cwd: "/",
+      git_root: null,
+    });
+
+    const found = peers.find((p) => p.id === reg.id);
+    expect(found).toBeTruthy();
+    expect(found!.tmux_session).toBeNull();
+    expect(found!.tmux_window_index).toBeNull();
+    expect(found!.tmux_window_name).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Peer IDs are random 8-char strings (e.g. `c0ktz8ga`). To message "the peer in tmux window 4" or "the architect session", users have to manually cross-reference `tmux list-panes` output against `list_peers` TTY fields, then send to a random ID. This is friction every time you have multiple Claude sessions running.

## Solution

Two small, complementary features:

### F1 — Named aliases via `CLAUDE_PEER_NAME` env var

Launch a session with a human-readable name:
\`\`\`bash
CLAUDE_PEER_NAME=mary claude --dangerously-load-development-channels server:claude-peers
\`\`\`

The name is stored in a new `name` column on the broker. New `find_peer({name?, tmux?})` MCP tool resolves names directly to peer IDs.

### F2 — Process-ancestry tmux detection

At peer registration, walk `process.ppid` upward, matching against `tmux list-panes -a -F "#{pane_pid} ..."`. If a match is found within 20 iterations, auto-tag the peer with `tmux_session`, `tmux_window_index`, `tmux_window_name`. The auto-summary gets a `[tmux session:window]` prefix.

This works even when the `tty` field is unavailable or unreliable. Tested live against tmux session `mgt`, peer correctly identified as `Tmux: mgt:1:claude`.

## Backward compatibility

- All 4 new columns are nullable, added via idempotent `ALTER TABLE` migrations
- Peers launched without `CLAUDE_PEER_NAME` get `name: null`
- Peers launched outside tmux get null `tmux_*` fields
- Existing peers in the DB continue to work unchanged
- `find_peer` returns empty array for no matches (graceful)

## Test coverage

28 tests / 82 assertions across 4 describe blocks in `tests/f1-f2.test.ts`:

- **Schema migrations**: column existence, idempotency
- **F1 broker round-trip**: register with/without name, list_peers retrieval
- **F2 broker round-trip**: register with/without tmux fields, list_peers retrieval
- **find_peer filtering**: by name, by tmux, by both, no-match cases
- **Type contracts**: RegisterRequest + Peer with new fields
- **detectTmuxPane parsing**: tmux output parsing edge cases (empty, malformed, single-pane, names-with-spaces)
- **Ancestry walk simulation**: match within 20 iterations, no-match, ppid=1 early termination
- **Live broker integration**: 4 end-to-end tests against a real broker on an isolated port

Run with: \`bun test tests/f1-f2.test.ts\`

## Files changed

- \`server.ts\` — \`detectTmuxPane()\`, env var read, \`find_peer\` tool, \`list_peers\` display update
- \`broker.ts\` — schema migrations, \`insertPeer\` expansion
- \`shared/types.ts\` — \`Peer\` + \`RegisterRequest\` field additions
- \`tests/f1-f2.test.ts\` — new test suite

Net: +687 / -3 lines (mostly tests).

## Verification

Ran live on a machine with 9 active peers across 6+ tmux sessions. The peer launched in tmux session \`mgt\` correctly auto-detected and showed \`Tmux: mgt:1:claude\` in \`list_peers\`. Existing peers (registered before the schema migration) continued to work with null fields.