### PR TITLE
Use process.execPath when spawning broker

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -71,7 +71,7 @@ async function ensureBroker(): Promise<void> {
   }
 
   log("Starting broker daemon...");
-  const proc = Bun.spawn(["bun", BROKER_SCRIPT], {
+  const proc = Bun.spawn([process.execPath, BROKER_SCRIPT], {
     stdio: ["ignore", "ignore", "inherit"],
     // Detach so the broker survives if this MCP server exits
     // On macOS/Linux, the broker will keep running


### PR DESCRIPTION
## Problem

`server.ts:74` calls `Bun.spawn(["bun", BROKER_SCRIPT])`, which relies on `bun` being on the `$PATH` of the spawned process. When the MCP server is launched by a Claude Code client, the process environment is minimal and `~/.bun/bin` (the default install location from `curl -fsSL https://bun.sh/install | bash`) is not always present. The broker daemon fails with:

```
Fatal: Executable not found in $PATH: "bun"
```

This is a real failure mode on macOS with the official Bun installer, since Homebrew-installed Bun requires Xcode CLI tools and `$HOME/.bun/bin` is only added to interactive shell profiles by the installer.

## Fix

Replace `"bun"` with `process.execPath`, the absolute path of the currently-running Bun binary. No `$PATH` dependency, works identically across Linux and macOS regardless of install location.

## Test plan

- [x] MCP server starts and spawns broker successfully on macOS (Apple Silicon, Bun installed via official script at `$HOME/.bun/bin/bun`)
- [x] MCP server starts and spawns broker successfully on Linux (Bun via official script)
- [x] No behavior change when `bun` happens to be on `$PATH` anyway
