### PR TITLE
Add summary_updated_at to Peer for activity-proxy tooling

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -41,9 +41,21 @@ db.run(`
     tty TEXT,
     summary TEXT NOT NULL DEFAULT '',
     registered_at TEXT NOT NULL,
-    last_seen TEXT NOT NULL
+    last_seen TEXT NOT NULL,
+    summary_updated_at TEXT NOT NULL DEFAULT ''
   )
 `);
+
+// Migration: add summary_updated_at column to pre-existing peers tables.
+// bun:sqlite's ALTER TABLE doesn't support IF NOT EXISTS, so guard with PRAGMA.
+{
+  const cols = db.query("PRAGMA table_info(peers)").all() as { name: string }[];
+  if (!cols.some((c) => c.name === "summary_updated_at")) {
+    db.run(`ALTER TABLE peers ADD COLUMN summary_updated_at TEXT NOT NULL DEFAULT ''`);
+    // Backfill existing rows with last_seen as a reasonable default.
+    db.run(`UPDATE peers SET summary_updated_at = last_seen WHERE summary_updated_at = ''`);
+  }
+}
 
 db.run(`
   CREATE TABLE IF NOT EXISTS messages (
@@ -81,8 +93,8 @@ setInterval(cleanStalePeers, 30_000);
 // --- Prepared statements ---
 
 const insertPeer = db.prepare(`
-  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, registered_at, last_seen)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  INSERT INTO peers (id, pid, cwd, git_root, tty, summary, registered_at, last_seen, summary_updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 const updateLastSeen = db.prepare(`
@@ -90,7 +102,7 @@ const updateLastSeen = db.prepare(`
 `);
 
 const updateSummary = db.prepare(`
-  UPDATE peers SET summary = ? WHERE id = ?
+  UPDATE peers SET summary = ?, summary_updated_at = ? WHERE id = ?
 `);
 
 const deletePeer = db.prepare(`
@@ -145,7 +157,7 @@ function handleRegister(body: RegisterRequest): RegisterResponse {
     deletePeer.run(existing.id);
   }
 
-  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now);
+  insertPeer.run(id, body.pid, body.cwd, body.git_root, body.tty, body.summary, now, now, now);
   return { id };
 }
 
@@ -154,7 +166,8 @@ function handleHeartbeat(body: HeartbeatRequest): void {
 }
 
 function handleSetSummary(body: SetSummaryRequest): void {
-  updateSummary.run(body.summary, body.id);
+  const now = new Date().toISOString();
+  updateSummary.run(body.summary, now, body.id);
 }
 
 function handleListPeers(body: ListPeersRequest): Peer[] {

--- a/server.ts
+++ b/server.ts
@@ -269,6 +269,7 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
           if (p.git_root) parts.push(`Repo: ${p.git_root}`);
           if (p.tty) parts.push(`TTY: ${p.tty}`);
           if (p.summary) parts.push(`Summary: ${p.summary}`);
+          if (p.summary_updated_at) parts.push(`Summary updated: ${p.summary_updated_at}`);
           parts.push(`Last seen: ${p.last_seen}`);
           return parts.join("\n  ");
         });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -9,7 +9,8 @@ export interface Peer {
   tty: string | null;
   summary: string;
   registered_at: string; // ISO timestamp
-  last_seen: string; // ISO timestamp
+  last_seen: string; // ISO timestamp — updated on every heartbeat
+  summary_updated_at: string; // ISO timestamp — updated when summary changes (register or set_summary)
 }
 
 export interface Message {


### PR DESCRIPTION
## Problem

`last_seen` advances on every heartbeat, so it can't tell you whether a peer is *actively working* or just *still alive*. Downstream tooling that wants a "has this peer made progress recently?" signal has no good field to key off.

## Change

Adds `summary_updated_at` to `Peer`. Set on register, advanced whenever `set_summary` is called. Exposed in the `list_peers` MCP output as a new line between the summary and `Last seen`.

## Use case

I'm running a peer-watchdog that alerts when a live peer has held a stale claim for too long. Today it uses the `since` field in the claims file as a proxy, which is fragile (never updates once the claim is registered). With `summary_updated_at`, the watchdog can compare it against the claim age and flag peers whose work has clearly moved on.

I expect this is generically useful for:
- Idle-peer detection in orchestration scripts
- \"Who's actually working right now?\" dashboards
- Exit-at-merge enforcement (compare summary_updated_at to PR state)

## Schema migration

Existing DBs migrate on broker startup: a `PRAGMA table_info` check, then `ALTER TABLE ADD COLUMN` with a `''` default, then a one-time backfill setting existing rows to their `last_seen`. `bun:sqlite` doesn't support `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, hence the pragma guard.

## Test plan

Tested locally:

- Fresh DB — register + list → `summary_updated_at` populated, equal to `registered_at`.
- set_summary → `summary_updated_at` advances, `last_seen` does not (since no heartbeat fired).
- Existing pre-migration DB — schema migration adds the column, backfills all rows to their `last_seen`, new writes set current time. Verified against my production broker's DB copy (5 rows, all backfilled correctly).

Happy to add a bun test if you'd like; let me know.