### PR TITLE
fix(windows): strip leading-slash from URL.pathname for BROKER_SCRIPT

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -38,7 +38,9 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+// On Windows, URL.pathname returns a leading-slash form like "/C:/path/file.ts"
+// which Bun.spawn cannot resolve. Strip the leading slash before drive-letter.
+const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
 
 // --- Broker communication ---
 


### PR DESCRIPTION
## Problem

On Windows, `new URL("./broker.ts", import.meta.url).pathname` returns
a leading-slash form like `/C:/Users/.../broker.ts` because file:// URLs
encode Windows drive paths with a leading slash. `Bun.spawn` does not
recognize this form and fails with:

    error: Module not found "/C:/Users/Daniele/claude-peers-mcp/broker.ts"

This blocks the broker daemon from spawning on every Windows install,
independent of the PATH issue addressed by #42.

## Fix

Strip the leading slash when the next character is a drive letter, so
the path becomes `C:/Users/.../broker.ts`. macOS/Linux paths do not
match the regex and are unaffected.

## Test plan

- [x] Windows 11, bun 1.3.13: with this fix plus #42 (process.execPath),
      the MCP server starts and registers as a peer successfully under
      Claude Code stdio MCP launch. Broker logs:
      `[claude-peers broker] listening on 127.0.0.1:7899`
      `[claude-peers] Registered as peer rqqofrk9`
      `[claude-peers] MCP connected`
- [x] No change on macOS/Linux: regex `^\/([A-Za-z]:)` only matches
      Windows drive-letter paths.

## Relation to other PRs

Companion to #42 ("Use process.execPath when spawning broker"). Each PR
fixes one independent failure mode on Windows: #42 fixes "bun not in
PATH" and this fixes "BROKER_SCRIPT path malformed". Both are needed
for end-to-end Windows compatibility.

---

Disclaimer: this PR, the code change in 036511b, and the verification
described above were drafted by Kloud AI assistant (kloud@gravya.it)
under human review and approval. Human in the loop: GravyaDev.