### PR TITLE
Add human-readable peer IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In another terminal, start Claude Code the same way. Then ask either one:
 
 > List all peers on this machine
 
-It'll show every running instance with their working directory, git repo, and a summary of what they're doing. Then:
+It'll show every running instance with their working directory, git repo, summary, and a readable ID like `ancient-brave-otter`. Then:
 
 > Send a message to peer [id]: "what are you working on?"
 

--- a/broker.ts
+++ b/broker.ts
@@ -10,6 +10,7 @@
  */
 
 import { Database } from "bun:sqlite";
+import { uniqueNamesGenerator, adjectives, animals } from "unique-names-generator";
 import type {
   RegisterRequest,
   RegisterResponse,
@@ -101,6 +102,10 @@ const selectAllPeers = db.prepare(`
   SELECT * FROM peers
 `);
 
+const selectPeerById = db.prepare(`
+  SELECT id FROM peers WHERE id = ?
+`);
+
 const selectPeersByDirectory = db.prepare(`
   SELECT * FROM peers WHERE cwd = ?
 `);
@@ -125,12 +130,22 @@ const markDelivered = db.prepare(`
 // --- Generate peer ID ---
 
 function generateId(): string {
-  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-  let id = "";
-  for (let i = 0; i < 8; i++) {
-    id += chars[Math.floor(Math.random() * chars.length)];
+  for (let i = 0; i < 32; i++) {
+    const id = uniqueNamesGenerator({
+      dictionaries: [adjectives, adjectives, animals],
+      separator: "-",
+      style: "lowerCase",
+    });
+    const existing = selectPeerById.get(id) as { id: string } | null;
+    if (!existing) return id;
   }
-  return id;
+
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return `${uniqueNamesGenerator({
+    dictionaries: [adjectives, animals],
+    separator: "-",
+    style: "lowerCase",
+  })}-${suffix}`;
 }
 
 // --- Request handlers ---

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "claude-peers",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "unique-names-generator": "^4.7.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -195,6 +196,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unique-names-generator": ["unique-names-generator@4.7.1", "", {}, "sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1"
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "unique-names-generator": "^4.7.1"
   }
 }


### PR DESCRIPTION
## Summary
- Replace 8-character random peer IDs with adjective-adjective-animal slugs like `ancient-brave-otter`.
- Use `unique-names-generator`, a TypeScript-friendly npm package with built-in dictionaries and types.
- Check for slug collisions before registration and keep a random suffix fallback for rare repeated collisions.

## Notes
- Existing open PR https://github.com/louislva/claude-peers-mcp/pull/38 adds named aliases via `CLAUDE_PEER_NAME`; this keeps scope narrower by changing the generated peer ID itself.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] Smoke test readable ID generation with Bun
- [ ] `bun test` (repo currently has no test files, command exits with "0 test files")

t. Clanker :robot: