### PR TITLE
Separate pushed from delivered + add TTL cleanup

### DIFF
--- a/broker.ts
+++ b/broker.ts
@@ -70,6 +70,15 @@ if (!messagesCols.some((c) => c.name === "pushed")) {
   db.run("ALTER TABLE messages ADD COLUMN pushed INTEGER NOT NULL DEFAULT 0");
 }
 
+// Idempotent migration: add 'expired_at' column for per-message TTL.
+// A periodic sweep marks expired_at on rows older than CLAUDE_PEERS_TTL_HOURS
+// (default 24h) and delivered=0. We do NOT mark delivered=1 on expired rows
+// because that would falsify the consumption signal — the audit trail must
+// distinguish "model consumed it" from "broker stopped trying after TTL".
+if (!messagesCols.some((c) => c.name === "expired_at")) {
+  db.run("ALTER TABLE messages ADD COLUMN expired_at TEXT DEFAULT NULL");
+}
+
 // Clean up stale peers (PIDs that no longer exist) on startup
 function cleanStalePeers() {
   const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
@@ -89,6 +98,22 @@ cleanStalePeers();
 
 // Periodically clean stale peers (every 30s)
 setInterval(cleanStalePeers, 30_000);
+
+// TTL sweep: mark expired_at on undelivered messages older than
+// CLAUDE_PEERS_TTL_HOURS (default 24h). Set the env var to "0" to disable.
+const TTL_HOURS = parseInt(process.env.CLAUDE_PEERS_TTL_HOURS ?? "24", 10);
+
+function expireOldMessages() {
+  if (TTL_HOURS <= 0) return;
+  const cutoff = new Date(Date.now() - TTL_HOURS * 3600 * 1000).toISOString();
+  db.run(
+    "UPDATE messages SET expired_at = ? WHERE delivered = 0 AND expired_at IS NULL AND sent_at < ?",
+    [new Date().toISOString(), cutoff],
+  );
+}
+
+expireOldMessages();
+setInterval(expireOldMessages, 5 * 60 * 1000); // every 5 min
 
 // --- Prepared statements ---
 
@@ -127,13 +152,13 @@ const insertMessage = db.prepare(`
 `);
 
 const selectUndelivered = db.prepare(`
-  SELECT * FROM messages WHERE to_id = ? AND delivered = 0 ORDER BY sent_at ASC
+  SELECT * FROM messages WHERE to_id = ? AND delivered = 0 AND expired_at IS NULL ORDER BY sent_at ASC
 `);
 
 // Auto-push loop reads via selectUnpushed; check_messages tool (manual
 // fallback) reads via selectUndelivered. Two flags, two consumers.
 const selectUnpushed = db.prepare(`
-  SELECT * FROM messages WHERE to_id = ? AND pushed = 0 AND delivered = 0 ORDER BY sent_at ASC
+  SELECT * FROM messages WHERE to_id = ? AND pushed = 0 AND delivered = 0 AND expired_at IS NULL ORDER BY sent_at ASC
 `);
 
 const markDelivered = db.prepare(`

--- a/broker.ts
+++ b/broker.ts
@@ -58,6 +58,18 @@ db.run(`
   )
 `);
 
+// Idempotent migration: add 'pushed' column on existing databases.
+// 'pushed' decouples the auto-push loop's drain from the manual fallback's
+// drain. Without this, /poll-messages marked delivered=1 at first call
+// (whether from auto-push or check_messages), so on hosts that drop
+// claude/channel notifications (Antigravity, Zed, CLI without
+// --dangerously-load-development-channels), the manual check_messages
+// always saw an empty queue.
+const messagesCols = db.query("PRAGMA table_info(messages)").all() as { name: string }[];
+if (!messagesCols.some((c) => c.name === "pushed")) {
+  db.run("ALTER TABLE messages ADD COLUMN pushed INTEGER NOT NULL DEFAULT 0");
+}
+
 // Clean up stale peers (PIDs that no longer exist) on startup
 function cleanStalePeers() {
   const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
@@ -118,8 +130,18 @@ const selectUndelivered = db.prepare(`
   SELECT * FROM messages WHERE to_id = ? AND delivered = 0 ORDER BY sent_at ASC
 `);
 
+// Auto-push loop reads via selectUnpushed; check_messages tool (manual
+// fallback) reads via selectUndelivered. Two flags, two consumers.
+const selectUnpushed = db.prepare(`
+  SELECT * FROM messages WHERE to_id = ? AND pushed = 0 AND delivered = 0 ORDER BY sent_at ASC
+`);
+
 const markDelivered = db.prepare(`
   UPDATE messages SET delivered = 1 WHERE id = ?
+`);
+
+const markPushed = db.prepare(`
+  UPDATE messages SET pushed = 1 WHERE id = ?
 `);
 
 // --- Generate peer ID ---
@@ -219,6 +241,21 @@ function handlePollMessages(body: PollMessagesRequest): PollMessagesResponse {
   return { messages };
 }
 
+// Auto-push consumer: reads only rows that have not been pushed yet.
+// Marks pushed=1 so subsequent push-polls don't re-emit. Does NOT touch
+// delivered=0, so the manual check_messages fallback can still drain
+// them via /poll-messages if the channel notification was dropped at
+// host level.
+function handlePushPollMessages(body: PollMessagesRequest): PollMessagesResponse {
+  const messages = selectUnpushed.all(body.id) as Message[];
+
+  for (const msg of messages) {
+    markPushed.run(msg.id);
+  }
+
+  return { messages };
+}
+
 function handleUnregister(body: { id: string }): void {
   deletePeer.run(body.id);
 }
@@ -257,6 +294,8 @@ Bun.serve({
           return Response.json(handleSendMessage(body as SendMessageRequest));
         case "/poll-messages":
           return Response.json(handlePollMessages(body as PollMessagesRequest));
+        case "/push-poll-messages":
+          return Response.json(handlePushPollMessages(body as PollMessagesRequest));
         case "/unregister":
           handleUnregister(body as { id: string });
           return Response.json({ ok: true });

--- a/server.ts
+++ b/server.ts
@@ -405,7 +405,11 @@ async function pollAndPushMessages() {
   if (!myId) return;
 
   try {
-    const result = await brokerFetch<PollMessagesResponse>("/poll-messages", { id: myId });
+    // Use /push-poll-messages so this auto-push consumer marks pushed=1
+    // (not delivered=1). The manual check_messages tool still uses
+    // /poll-messages and continues to mark delivered=1 — that's the
+    // canonical "model consumed" signal. Two endpoints, two flags.
+    const result = await brokerFetch<PollMessagesResponse>("/push-poll-messages", { id: myId });
 
     for (const msg of result.messages) {
       // Look up the sender's info for context


### PR DESCRIPTION
## Summary

Two independent bug fixes for inbox-queue management:

### 1. Separate `pushed` from `delivered` flag (queue-drain bug)

Today the single `delivered` flag is shared between the auto-push loop in `server.ts` (which polls every 1s and emits `notifications/claude/channel`) and the manual `check_messages` tool (the documented fallback). Both call `/poll-messages` which marks `delivered=1` immediately. Result: auto-push always drains the queue first; on hosts that don't promote `claude/channel` to the model (Claude Code CLI without `--dangerously-load-development-channels`, Antigravity, Zed), the channel notification is silently dropped, and `check_messages` then finds `[]`.

This PR adds a separate `pushed` column. New endpoint `/push-poll-messages` marks `pushed=1` (used by the auto-push loop). Existing `/poll-messages` continues to mark `delivered=1` (used by `check_messages` and any future polling consumer that wants the manual semantics). Each path is independent.

End-to-end verification (transcript from real test against this branch):

```
send             → row inserted (pushed=0, delivered=0)
push-poll        → returns row, sets pushed=1, delivered stays 0
push-poll again  → empty (filtered by pushed=0)
poll-messages    → returns row again, sets delivered=1
poll-messages again → empty
```

### 2. Per-message TTL via `expired_at` column

Today there is no message TTL. A peer that goes offline for weeks accumulates messages in its inbox forever; when it returns, it gets blasted with stale conversation.

This PR adds an `expired_at` column. A 5-minute sweep marks `expired_at = <now>` on rows where `delivered=0 AND sent_at < (now - CLAUDE_PEERS_TTL_HOURS hours)`. Default TTL: 24h, configurable via the env var (set to `"0"` to disable). `selectUndelivered` and `selectUnpushed` filter `AND expired_at IS NULL`, so expired rows are no longer returned by either poll endpoint.

**Audit-trail design**: expired rows are NOT marked `delivered=1` — that would falsify the consumption signal. A row with `delivered=0 + expired_at=<ts>` correctly means "model never consumed it, broker stopped trying after the TTL". A separate future feature (out of scope of this PR) could notify the sender when a message expires unread.

## Files changed

- `broker.ts` — `pushed` and `expired_at` migrations (idempotent via PRAGMA check), `selectUnpushed` / `markPushed` prepared statements, `/push-poll-messages` HTTP route, `expireOldMessages()` + interval, updated existing prepared statements to filter expired rows.
- `server.ts` — `pollAndPushMessages()` switched from `/poll-messages` to `/push-poll-messages` (one-line change; added clarifying comment).

## Test plan

- [x] Lifecycle test for queue separation (4-step transcript above; verified end-to-end).
- [x] TTL test: insert a message, backdate to 25h via `UPDATE messages SET sent_at = datetime("now", "-25 hours")`, run `expireOldMessages()`, confirm `expired_at` populates and the message is no longer returned by either `selectUndelivered` or `selectUnpushed`.
- [ ] Reviewer to verify against their dev environment.

## Backward compatibility

The migrations are idempotent (`PRAGMA table_info` check before `ALTER TABLE`). Pre-existing rows get `pushed=0, expired_at=NULL` defaults — they replay correctly through the new flow.

A consumer running a pre-PR `server.ts` against a post-PR `broker.ts` continues to work (it just calls the old `/poll-messages` endpoint, which now drains the manual queue rather than the auto-push queue — semantically more correct than before).

## Configuration

`CLAUDE_PEERS_TTL_HOURS` env var. Defaults to `24`. Set to `0` to disable TTL (messages never expire — same as pre-PR behavior).

## Note on a related limitation (not addressed here)

While testing, I noticed that `cleanStalePeers()` runs `DELETE FROM messages WHERE to_id = ? AND delivered = 0` for any peer whose PID has died. This deletes both undelivered AND expired-but-not-delivered rows indiscriminately. Strictly speaking this is correct (the peer is gone, the inbox is gone), but it does mean the audit trail of expired messages is also lost when a peer disappears. Cleanest version would distinguish "undelivered for a live peer" from "expired" with separate cleanup. Leaving as-is to keep this PR scoped — happy to follow up in a separate PR if you want.

---
*Disclaimer: this PR, the code changes in it, the empirical end-to-end repro evidence, and the TTL test methodology were drafted by Kloud AI assistant (kloud@gravya.it) under human review and approval. Human in the loop: GravyaDev.*