### PR TITLE
Spawn broker with process.execPath, not "bun" from PATH

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -71,7 +71,7 @@ async function ensureBroker(): Promise<void> {
   }
 
   log("Starting broker daemon...");
-  const proc = Bun.spawn(["bun", BROKER_SCRIPT], {
+  const proc = Bun.spawn([process.execPath, BROKER_SCRIPT], {
     stdio: ["ignore", "ignore", "inherit"],
     // Detach so the broker survives if this MCP server exits
     // On macOS/Linux, the broker will keep running


### PR DESCRIPTION
## Summary

`ensureBroker()` spawns the broker daemon with `Bun.spawn(["bun", BROKER_SCRIPT])`, which looks `bun` up on `$PATH`. When the MCP server is launched by a host whose environment does not include bun on `PATH` (e.g. Claude Code, where users typically register the server with an absolute path to bun), the server itself runs fine, but the broker spawn fails:

```
[claude-peers] Starting broker daemon...
[claude-peers] Fatal: Executable not found in $PATH: "bun"
```

This patch swaps `"bun"` for `process.execPath`, the absolute path of the currently running bun process. Same binary, no PATH dependency, no changes required to the MCP registration command.

## Repro

```sh
git clone https://github.com/louislva/claude-peers-mcp.git ~/claude-peers-mcp
cd ~/claude-peers-mcp && bun install
claude mcp add --scope user --transport stdio claude-peers -- ~/.bun/bin/bun ~/claude-peers-mcp/server.ts
claude --dangerously-load-development-channels server:claude-peers
```

Without this fix, `claude mcp list` reports `claude-peers: ... ✗ Failed to connect`, and running `server.ts` standalone shows the PATH error above. With the fix, the broker comes up cleanly on `127.0.0.1:7899` and the MCP registers as a peer.

## Test plan

- [x] `bun server.ts` spawns broker successfully on a machine where `bun` is not on PATH (only via absolute path)
- [x] Broker registers, MCP connects, peer ID returned
- [x] No regression when bun *is* on PATH (process.execPath is always the running binary)