### PR TITLE
fix(server): use fileURLToPath for broker script path on Windows

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -13,6 +13,7 @@
  *   { "claude-peers": { "command": "bun", "args": ["./server.ts"] } }
  */
 
+import { fileURLToPath } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -38,7 +39,7 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+const BROKER_SCRIPT = fileURLToPath(new URL("./broker.ts", import.meta.url));
 
 // --- Broker communication ---
 


### PR DESCRIPTION
## Summary

Fixes a Windows-only failure where the MCP server can't spawn the broker daemon.

`new URL("./broker.ts", import.meta.url).pathname` returns a string like `/C:/Users/.../broker.ts` (leading slash before the drive letter) on Windows. Bun then can't resolve it:

```
[claude-peers] Starting broker daemon...
error: Module not found "/C:/Users/.../claude-peers-mcp/broker.ts"
```

`fileURLToPath` from `node:url` handles the platform-specific conversion correctly: `C:\Users\...\broker.ts` on Windows, unchanged on Unix.

## Changes

- `server.ts`: import `fileURLToPath` from `node:url` and wrap the broker URL with it.

2-line diff, no behavior change on macOS/Linux.

## Test plan

- [x] On Windows (bun 1.3.14): MCP server starts, broker spawns, peer registers, `list_peers` / `send_message` tools work end-to-end.
- [ ] On macOS / Linux: no regression — `fileURLToPath(file:///path)` returns `/path`, matching previous `.pathname` behavior.