### PR TITLE
Detect orphaned MCP server and exit cleanly

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -521,6 +521,14 @@ async function main() {
 
   // 7. Start heartbeat
   const heartbeatTimer = setInterval(async () => {
+    // Orphan detection: if our Claude Code parent exited, we were reparented
+    // to init/launchd (PPID=1) and would otherwise keep advertising liveness
+    // to the broker indefinitely. Unregister and exit cleanly instead.
+    if (process.ppid === 1) {
+      log("Parent exited (PPID=1) — orphaned, cleaning up");
+      await cleanup();
+      return;
+    }
     if (myId) {
       try {
         await brokerFetch("/heartbeat", { id: myId });


### PR DESCRIPTION
## Problem

When a Claude Code instance exits or crashes, its stdio `bun server.ts` MCP subprocess is reparented to init/launchd (PPID=1) but continues running indefinitely. The existing `cleanStalePeers()` sweep in `broker.ts` checks if the registered PID is alive via `process.kill(pid, 0)` — but the bun MCP server PID *is* alive; only the Claude parent died. Result: orphaned bun servers keep heartbeating to the broker forever, and `list_peers` returns phantom entries with fresh `last_seen` timestamps.

Observed on macOS: 6 orphaned `bun /path/to/server.ts` processes all with `PPID=1` (adopted by launchd), each still firing the 15s heartbeat. They showed up as live peers in `list_peers` even though their owning Claude sessions had been gone for hours.

## Fix

At each heartbeat tick, check `process.ppid`. If it has become `1`, we were reparented after our parent exited — run `cleanup()` to unregister from the broker, then exit. Worst-case detection latency = `HEARTBEAT_INTERVAL_MS` (15s). After self-exit, the broker's existing 30s `cleanStalePeers` sweep removes the entry naturally on its next pass.

Minimal change — 8 lines, comment included.

## Test plan

- [x] `bunx tsc --noEmit -p tsconfig.json` passes
- [x] Manual: confirmed orphaned bun processes on macOS reach `PPID=1` after Claude Code parent exits, so the check fires correctly
- [ ] Run multiple Claude Code sessions, kill some, observe `list_peers` no longer returns phantoms within ~45s

## Notes

- Doesn't touch existing SIGINT/SIGTERM cleanup or the broker side — least-surface fix.
- 15s detection window is fine for normal operation; if anyone wants faster pruning, the same check could be added to the message-poll loop (1s cadence) but that doubles the surface area for a problem that resolves within a heartbeat anyway.