### PR TITLE
fix(windows): broker auto-spawn on Windows (fileURLToPath + detached)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -19,6 +19,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { fileURLToPath } from "node:url";
 import type {
   PeerId,
   Peer,
@@ -38,7 +39,9 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+// `fileURLToPath` normalizes the path on Windows. `new URL(...).pathname` returns
+// "/C:/Users/.../broker.ts" with a leading slash, which `Bun.spawn` cannot resolve.
+const BROKER_SCRIPT = fileURLToPath(new URL("./broker.ts", import.meta.url));
 
 // --- Broker communication ---
 
@@ -71,10 +74,14 @@ async function ensureBroker(): Promise<void> {
   }
 
   log("Starting broker daemon...");
+  // Detach so the broker survives if this MCP server exits.
+  // On Windows, `proc.unref()` alone is not enough — the OS has no Unix detach semantics,
+  // and `stdio: [..., "inherit"]` for stderr ties the broker's stderr handle to the parent.
+  // When the MCP server exits, the broker would die trying to write to a closed handle.
+  // `detached: true` + all-ignore stdio breaks both ties; on macOS/Linux it is harmless.
   const proc = Bun.spawn(["bun", BROKER_SCRIPT], {
-    stdio: ["ignore", "ignore", "inherit"],
-    // Detach so the broker survives if this MCP server exits
-    // On macOS/Linux, the broker will keep running
+    stdio: ["ignore", "ignore", "ignore"],
+    detached: true,
   });
 
   // Unref so this process can exit without waiting for the broker


### PR DESCRIPTION
## Summary

On Windows, the broker daemon does not auto-spawn the way the README promises. Every Claude Code session opens with `claude mcp list` showing `claude-peers ✗ Failed to connect`, and the only workaround is launching `bun broker.ts` manually first. This PR fixes two underlying Windows-specific issues so the README behavior (`The broker daemon starts automatically the first time`) holds on Windows too.

## Symptoms (before)

- `claude mcp list` → `claude-peers ✗ Failed to connect`
- The MCP server's `ensureBroker()` logs `Starting broker daemon...` but `isBrokerAlive()` polls all 30 times and exits fatal
- Manually running `bun broker.ts` first → MCP server connects fine on the next session

## Root causes

**1. Path resolution.** `new URL("./broker.ts", import.meta.url).pathname` on Windows returns `/C:/Users/.../broker.ts` (with a leading slash). `Bun.spawn` cannot resolve that — the `bun` child either fails to find the script or treats the path as malformed.

**2. Process detach.** Two compounding problems:
- `proc.unref()` only lets the parent exit without waiting; it does **not** detach the child from the parent's process tree (Windows has no Unix detach semantics).
- `stdio: ["ignore", "ignore", "inherit"]` ties the broker's stderr handle to the parent MCP server's stderr. When the MCP server exits, that handle is closed; the broker dies the next time it writes to stderr.

The combined effect: even when spawn succeeds, the broker is short-lived, and the 30-attempt `isBrokerAlive()` poll exhausts before the broker has a chance to bind `:7899`.

## Fix

Three minimal changes in `server.ts`:

1. Add `import { fileURLToPath } from "node:url";`
2. Compute `BROKER_SCRIPT` via `fileURLToPath(new URL("./broker.ts", import.meta.url))` instead of `.pathname`.
3. Bun.spawn options: `stdio: ["ignore", "ignore", "ignore"]` + `detached: true`.

On macOS/Linux, `detached: true` with all-ignore stdio is harmless — the broker keeps running as before (the existing comment said it would on Unix; with these changes it does on Windows too).

## Verification (Windows 11, Bun)

Repro setup: ensure no broker process is running (`Invoke-WebRequest http://127.0.0.1:7899/health` → connection refused).

1. Start `bun server.ts` in the background (stdio MCP server, holds stdin).
2. Wait 4 s, then `GET http://127.0.0.1:7899/health` → `200 {"status":"ok","peers":2}` ✓ (broker auto-spawned)
3. Kill the `server.ts` process.
4. `GET http://127.0.0.1:7899/health` → `200` ✓ (broker survived parent exit — `detached` actually took effect)

Both assertions that fail without this patch now pass.

## Notes

- No changes to broker logic, MCP protocol, or external behavior.
- macOS/Linux: detached + ignore-stdio is harmless; the existing intent ("broker survives parent exit on Unix") is preserved.
- Reviewers comfortable with `Bun.spawn` Windows semantics: worth a second look on whether `proc.unref()` is still needed alongside `detached: true`. I kept it for safety / parity with the original.