### PR TITLE
Make claude-peers cross-platform (fix Windows; keep macOS/Linux/BSD working)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ cd ~/claude-peers-mcp
 bun install
 ```
 
+> **Windows (PowerShell):** `~` isn't expanded in command arguments, so give an
+> explicit path — e.g. `git clone https://github.com/louislva/claude-peers-mcp.git C:\Users\you\claude-peers-mcp`,
+> then `cd C:\Users\you\claude-peers-mcp`. (Git Bash expands `~` normally.)
+
 ### 2. Register the MCP server
 
 This makes claude-peers available in every Claude Code session, from any directory:
@@ -32,6 +36,11 @@ claude mcp add --scope user --transport stdio claude-peers -- bun ~/claude-peers
 ```
 
 Replace `~/claude-peers-mcp` with wherever you cloned it.
+
+> **Windows:** claude-peers runs natively on Windows, macOS, Linux, and BSD. On
+> Windows, use the full path to the clone in place of `~` (PowerShell doesn't
+> expand `~` inside arbitrary arguments), e.g.
+> `claude mcp add --scope user --transport stdio claude-peers -- bun C:\Users\you\claude-peers-mcp\server.ts`.
 
 ### 3. Run Claude Code with the channel
 
@@ -107,11 +116,13 @@ bun cli.ts kill-broker       # stop the broker
 
 ## Configuration
 
-| Environment variable | Default              | Description                           |
-| -------------------- | -------------------- | ------------------------------------- |
-| `CLAUDE_PEERS_PORT`  | `7899`               | Broker port                           |
-| `CLAUDE_PEERS_DB`    | `~/.claude-peers.db` | SQLite database path                  |
-| `OPENAI_API_KEY`     | —                    | Enables auto-summary via gpt-5.4-nano |
+| Environment variable | Default                   | Description                           |
+| -------------------- | ------------------------- | ------------------------------------- |
+| `CLAUDE_PEERS_PORT`  | `7899`                    | Broker port                           |
+| `CLAUDE_PEERS_DB`    | `<home>/.claude-peers.db` | SQLite database path                  |
+| `OPENAI_API_KEY`     | —                         | Enables auto-summary via gpt-5.4-nano |
+
+`<home>` is resolved via the OS home directory — `~` on macOS/Linux/BSD, `%USERPROFILE%` on Windows.
 
 ## Requirements
 

--- a/broker.ts
+++ b/broker.ts
@@ -10,6 +10,8 @@
  */
 
 import { Database } from "bun:sqlite";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type {
   RegisterRequest,
   RegisterResponse,
@@ -24,7 +26,10 @@ import type {
 } from "./shared/types.ts";
 
 const PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
-const DB_PATH = process.env.CLAUDE_PEERS_DB ?? `${process.env.HOME}/.claude-peers.db`;
+// Use os.homedir() rather than process.env.HOME: HOME is undefined when the
+// process is spawned natively on Windows (which uses USERPROFILE), and
+// path.join produces the correct separator on every platform.
+const DB_PATH = process.env.CLAUDE_PEERS_DB ?? join(homedir(), ".claude-peers.db");
 
 // --- Database setup ---
 
@@ -58,15 +63,26 @@ db.run(`
   )
 `);
 
+// Check whether a process is still alive. process.kill(pid, 0) sends no signal —
+// it only probes existence. It throws ESRCH when the pid is truly gone, but EPERM
+// when the process EXISTS and we merely lack permission to signal it (a peer owned
+// by another user, or one running elevated while the broker is not). EPERM means
+// alive, so treat ONLY ESRCH as dead — evicting a peer is destructive and should
+// require positive proof of death. Same semantics on Windows, Linux, macOS, BSD.
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as { code?: string }).code !== "ESRCH";
+  }
+}
+
 // Clean up stale peers (PIDs that no longer exist) on startup
 function cleanStalePeers() {
   const peers = db.query("SELECT id, pid FROM peers").all() as { id: string; pid: number }[];
   for (const peer of peers) {
-    try {
-      // Check if process is still alive (signal 0 doesn't kill, just checks)
-      process.kill(peer.pid, 0);
-    } catch {
-      // Process doesn't exist, remove it
+    if (!isProcessAlive(peer.pid)) {
       db.run("DELETE FROM peers WHERE id = ?", [peer.id]);
       db.run("DELETE FROM messages WHERE to_id = ? AND delivered = 0", [peer.id]);
     }
@@ -101,12 +117,20 @@ const selectAllPeers = db.prepare(`
   SELECT * FROM peers
 `);
 
+// On case-insensitive filesystems (Windows), two sessions in the same directory
+// can report differently-cased paths (e.g. C:\Dev\App vs C:\dev\app) and would
+// otherwise fail to discover each other under "directory"/"repo" scope. Match
+// case-insensitively there. Gated on the broker's own platform: a blanket
+// COLLATE NOCASE would wrongly conflate genuinely distinct paths on
+// case-sensitive Linux/BSD (macOS resolves cwd casing itself, so it's unaffected).
+const PATH_COLLATE = process.platform === "win32" ? "COLLATE NOCASE" : "";
+
 const selectPeersByDirectory = db.prepare(`
-  SELECT * FROM peers WHERE cwd = ?
+  SELECT * FROM peers WHERE cwd = ? ${PATH_COLLATE}
 `);
 
 const selectPeersByGitRoot = db.prepare(`
-  SELECT * FROM peers WHERE git_root = ?
+  SELECT * FROM peers WHERE git_root = ? ${PATH_COLLATE}
 `);
 
 const insertMessage = db.prepare(`
@@ -184,16 +208,12 @@ function handleListPeers(body: ListPeersRequest): Peer[] {
     peers = peers.filter((p) => p.id !== body.exclude_id);
   }
 
-  // Verify each peer's process is still alive
+  // Verify each peer's process is still alive (only truly-gone pids are evicted)
   return peers.filter((p) => {
-    try {
-      process.kill(p.pid, 0);
-      return true;
-    } catch {
-      // Clean up dead peer
-      deletePeer.run(p.id);
-      return false;
-    }
+    if (isProcessAlive(p.pid)) return true;
+    // Clean up dead peer
+    deletePeer.run(p.id);
+    return false;
   });
 }
 
@@ -223,51 +243,72 @@ function handleUnregister(body: { id: string }): void {
   deletePeer.run(body.id);
 }
 
+function handleShutdown(): void {
+  // Exit shortly after so the HTTP response flushes to the caller first.
+  // This replaces the previous lsof/kill approach, which only worked on Unix.
+  setTimeout(() => process.exit(0), 100);
+}
+
 // --- HTTP Server ---
 
-Bun.serve({
-  port: PORT,
-  hostname: "127.0.0.1",
-  async fetch(req) {
-    const url = new URL(req.url);
-    const path = url.pathname;
+try {
+  Bun.serve({
+    port: PORT,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      const url = new URL(req.url);
+      const path = url.pathname;
 
-    if (req.method !== "POST") {
-      if (path === "/health") {
-        return Response.json({ status: "ok", peers: (selectAllPeers.all() as Peer[]).length });
+      if (req.method !== "POST") {
+        if (path === "/health") {
+          return Response.json({ status: "ok", peers: (selectAllPeers.all() as Peer[]).length });
+        }
+        return new Response("claude-peers broker", { status: 200 });
       }
-      return new Response("claude-peers broker", { status: 200 });
-    }
 
-    try {
-      const body = await req.json();
+      try {
+        const body = await req.json();
 
-      switch (path) {
-        case "/register":
-          return Response.json(handleRegister(body as RegisterRequest));
-        case "/heartbeat":
-          handleHeartbeat(body as HeartbeatRequest);
-          return Response.json({ ok: true });
-        case "/set-summary":
-          handleSetSummary(body as SetSummaryRequest);
-          return Response.json({ ok: true });
-        case "/list-peers":
-          return Response.json(handleListPeers(body as ListPeersRequest));
-        case "/send-message":
-          return Response.json(handleSendMessage(body as SendMessageRequest));
-        case "/poll-messages":
-          return Response.json(handlePollMessages(body as PollMessagesRequest));
-        case "/unregister":
-          handleUnregister(body as { id: string });
-          return Response.json({ ok: true });
-        default:
-          return Response.json({ error: "not found" }, { status: 404 });
+        switch (path) {
+          case "/register":
+            return Response.json(handleRegister(body as RegisterRequest));
+          case "/heartbeat":
+            handleHeartbeat(body as HeartbeatRequest);
+            return Response.json({ ok: true });
+          case "/set-summary":
+            handleSetSummary(body as SetSummaryRequest);
+            return Response.json({ ok: true });
+          case "/list-peers":
+            return Response.json(handleListPeers(body as ListPeersRequest));
+          case "/send-message":
+            return Response.json(handleSendMessage(body as SendMessageRequest));
+          case "/poll-messages":
+            return Response.json(handlePollMessages(body as PollMessagesRequest));
+          case "/unregister":
+            handleUnregister(body as { id: string });
+            return Response.json({ ok: true });
+          case "/shutdown":
+            handleShutdown();
+            return Response.json({ ok: true });
+          default:
+            return Response.json({ error: "not found" }, { status: 404 });
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return Response.json({ error: msg }, { status: 500 });
       }
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      return Response.json({ error: msg }, { status: 500 });
-    }
-  },
-});
+    },
+  });
+} catch (e) {
+  // Another broker won the port — a TOCTOU race when several sessions start at
+  // once (each sees no broker and spawns one). That broker is the singleton, so
+  // exit quietly with code 0 rather than crashing with a stack trace. Same
+  // EADDRINUSE behavior on Windows, Linux, macOS, and BSD.
+  if ((e as { code?: string }).code === "EADDRINUSE") {
+    console.error(`[claude-peers broker] port ${PORT} already in use — another broker is running`);
+    process.exit(0);
+  }
+  throw e;
+}
 
 console.error(`[claude-peers broker] listening on 127.0.0.1:${PORT} (db: ${DB_PATH})`);

--- a/cli.ts
+++ b/cli.ts
@@ -54,7 +54,7 @@ switch (cmd) {
           }>
         >("/list-peers", {
           scope: "machine",
-          cwd: "/",
+          cwd: process.cwd(),
           git_root: null,
         });
 
@@ -86,7 +86,7 @@ switch (cmd) {
         }>
       >("/list-peers", {
         scope: "machine",
-        cwd: "/",
+        cwd: process.cwd(),
         git_root: null,
       });
 
@@ -133,15 +133,13 @@ switch (cmd) {
     try {
       const health = await brokerFetch<{ status: string; peers: number }>("/health");
       console.log(`Broker has ${health.peers} peer(s). Shutting down...`);
-      // Find and kill the broker process on the port
-      const proc = Bun.spawnSync(["lsof", "-ti", `:${BROKER_PORT}`]);
-      const pids = new TextDecoder()
-        .decode(proc.stdout)
-        .trim()
-        .split("\n")
-        .filter((p) => p);
-      for (const pid of pids) {
-        process.kill(parseInt(pid), "SIGTERM");
+      // Ask the broker to shut itself down. This is cross-platform, unlike the
+      // previous lsof-based approach (lsof does not exist on Windows).
+      try {
+        await brokerFetch("/shutdown", {});
+      } catch {
+        // The broker exits mid-response, so the connection may drop before we
+        // read the reply — that is expected and means shutdown succeeded.
       }
       console.log("Broker stopped.");
     } catch {

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,7 @@ import {
   getGitBranch,
   getRecentFiles,
 } from "./shared/summarize.ts";
+import { fileURLToPath } from "node:url";
 
 // --- Configuration ---
 
@@ -38,7 +39,10 @@ const BROKER_PORT = parseInt(process.env.CLAUDE_PEERS_PORT ?? "7899", 10);
 const BROKER_URL = `http://127.0.0.1:${BROKER_PORT}`;
 const POLL_INTERVAL_MS = 1000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
-const BROKER_SCRIPT = new URL("./broker.ts", import.meta.url).pathname;
+// fileURLToPath, not URL.pathname: on Windows .pathname yields a broken
+// "/C:/Users/.../broker.ts" (leading slash, forward slashes) that Bun.spawn
+// cannot open. fileURLToPath returns the correct native path on every platform.
+const BROKER_SCRIPT = fileURLToPath(new URL("./broker.ts", import.meta.url));
 
 // --- Broker communication ---
 
@@ -71,13 +75,19 @@ async function ensureBroker(): Promise<void> {
   }
 
   log("Starting broker daemon...");
+  // Detach the broker into its own session/process group so it genuinely
+  // outlives this MCP server:
+  //   - detached: true → setsid() on POSIX, UV_PROCESS_DETACHED on Windows, so a
+  //     terminal-close SIGHUP / Ctrl-C aimed at this server's process group does
+  //     not also kill the shared broker (unref() alone does NOT do this).
+  //   - stdio all "ignore" → a detached daemon must not hold the parent's stderr.
+  //   - unref() → lets this process exit without waiting on the broker.
+  // (On Windows this detaches from the console; a kill-on-close Job object could
+  // still reap it, but ensureBroker() re-spawns the broker on the next start.)
   const proc = Bun.spawn(["bun", BROKER_SCRIPT], {
-    stdio: ["ignore", "ignore", "inherit"],
-    // Detach so the broker survives if this MCP server exits
-    // On macOS/Linux, the broker will keep running
+    stdio: ["ignore", "ignore", "ignore"],
+    detached: true,
   });
-
-  // Unref so this process can exit without waiting for the broker
   proc.unref();
 
   // Wait for it to come up
@@ -117,6 +127,11 @@ async function getGitRoot(cwd: string): Promise<string | null> {
 }
 
 function getTty(): string | null {
+  // TTY is a Unix concept and `ps -o tty=` is a Unix-only command. Windows has
+  // no equivalent, so skip the spawn entirely and report no TTY there.
+  if (process.platform === "win32") {
+    return null;
+  }
   try {
     // Try to get the parent's tty from the process tree
     const ppid = process.ppid;
@@ -531,7 +546,10 @@ async function main() {
   }, HEARTBEAT_INTERVAL_MS);
 
   // 8. Clean up on exit
+  let cleaningUp = false;
   const cleanup = async () => {
+    if (cleaningUp) return; // may be triggered by both a signal and stdin close
+    cleaningUp = true;
     clearInterval(pollTimer);
     clearInterval(heartbeatTimer);
     if (myId) {
@@ -547,6 +565,15 @@ async function main() {
 
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
+
+  // Windows has no deliverable SIGTERM (the supervisor force-kills the stdio
+  // child with TerminateProcess) and never sends SIGINT to a non-console child,
+  // so the signal handlers above never fire there. Claude Code closes this
+  // process's stdin when it tears the MCP server down on every platform, so
+  // stdin EOF/close is the portable shutdown hook — it also unregisters promptly
+  // on POSIX instead of waiting for the SIGTERM fallback.
+  process.stdin.on("end", cleanup);
+  process.stdin.on("close", cleanup);
 }
 
 main().catch((e) => {


### PR DESCRIPTION
Fixes the issues that prevented claude-peers from running on Windows, plus several portability/correctness problems found in a broader audit. Details in #73. Every change is runtime-portable and preserves existing macOS/Linux/BSD behavior; verified end-to-end on Windows 11 / Bun 1.3.14.

## Blocks Windows

- **`broker.ts` — DB path.** `${process.env.HOME}/.claude-peers.db` → `join(os.homedir(), ".claude-peers.db")`. `HOME` is undefined on Windows (it uses `USERPROFILE`), which produced a literal `undefined/...` path.
- **`server.ts` — broker script path.** `new URL(...).pathname` → `fileURLToPath(...)`. On Windows `.pathname` is `/C:/Users/.../broker.ts`, which `Bun.spawn` can't open, so the broker never started.

## Windows-broken features

- **`broker.ts` + `cli.ts` — portable `kill-broker`.** Add a `/shutdown` endpoint; `kill-broker` POSTs to it instead of shelling out to `lsof` (absent on Windows).
- **`server.ts` — `getTty()`.** Skip the Unix-only `ps -o tty=` spawn on `win32` (returns `null`, as before).
- **`server.ts` — graceful shutdown.** `SIGTERM`/`SIGINT` don't fire for a Windows stdio child, so unregister-on-exit never ran. Also trigger `cleanup()` on `process.stdin` `end`/`close` (Claude Code closes stdin on teardown on every platform); keep the signal handlers for POSIX. Guarded against double-invocation.
- **`broker.ts` — case-insensitive path matching.** Directory/repo scoping used case-sensitive `WHERE cwd = ?`; on Windows two sessions in the same dir with different casing didn't match. Add `COLLATE NOCASE` gated on `process.platform === "win32"` (a blanket collation would wrongly conflate distinct paths on Linux/BSD).
- **`README.md`** — add explicit-path Windows variants (step 1 clone/`cd` and the `claude mcp add` command), and document that the DB path resolves via the OS home dir.

## Cross-platform correctness

- **`broker.ts` — liveness check.** `process.kill(pid, 0)` was caught with a bare `catch` that deleted the peer on any error, including `EPERM` (process exists but can't be signaled — e.g. another user / elevated). Now only `ESRCH` (truly gone) evicts a peer. Applied at both call sites via an `isProcessAlive()` helper.
- **`server.ts` — broker detachment.** Add `detached: true` (setsid / `UV_PROCESS_DETACHED`) and `stdio: ["ignore","ignore","ignore"]` alongside `unref()`, so the singleton broker genuinely outlives a session's teardown instead of dying with its process group's `SIGHUP`.
- **`broker.ts` — `EADDRINUSE`.** Wrap `Bun.serve` so a broker that loses the concurrent-launch race exits 0 with a one-line message instead of an uncaught stack trace.

## Testing (Windows 11, Bun 1.3.14)

- `bun broker.ts` starts; default DB resolves to `C:\Users\<user>\.claude-peers.db`.
- `bun server.ts` auto-spawns the detached broker, registers, reaches "MCP connected"; the broker keeps serving after the server process exits; closing stdin logs "Unregistered from broker".
- `bun cli.ts status` / `kill-broker` work via `/shutdown`; a second broker on a busy port prints "port … already in use" and exits 0.
- A focused `bun:sqlite` test confirms `COLLATE NOCASE` matches `C:/Dev/CaseTest` ↔ `c:/dev/casetest` on win32, stays case-sensitive with no collation, and doesn't conflate distinct directories.
- `bunx tsc --noEmit` passes.

No behavioral change on macOS/Linux/BSD: the same `os.homedir()`/`fileURLToPath` values are produced there, the `ps` TTY path is unchanged off Windows, and path matching stays case-sensitive (no `COLLATE NOCASE`) on non-win32.
